### PR TITLE
Fixes #151

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Constants
 ```Pawn
 #define FCNPC_INCLUDE_VERSION		The current FCNPC include version.
 
+#define FCNPC_SHOOT_CHECK_NONE		(0)
+#define FCNPC_SHOOT_CHECK_PLAYER	(1)
+#define FCNPC_SHOOT_CHECK_NPC		(2)
+#define FCNPC_SHOOT_CHECK_ACTOR		(4)
+#define FCNPC_SHOOT_CHECK_VEHICLE	(8)
+#define FCNPC_SHOOT_CHECK_OBJECT	(16)
+#define FCNPC_SHOOT_CHECK_POBJECT_ORIG	(32)
+#define FCNPC_SHOOT_CHECK_POBJECT_TARG	(64)
+#define FCNPC_SHOOT_CHECK_MAP		(128)
+#define FCNPC_SHOOT_CHECK_ALL		(255)
+
 #define FCNPC_MOVE_TYPE_AUTO		(-1)
 #define FCNPC_MOVE_TYPE_WALK		(0)
 #define FCNPC_MOVE_TYPE_RUN		(1)
@@ -241,8 +252,8 @@ native bool:FCNPC_IsMoving(npcid);
 native bool:FCNPC_IsMovingAtPlayer(npcid, playerid);
 native FCNPC_GetDestinationPoint(npcid, &Float:x, &Float:y, &Float:z);
 
-native FCNPC_AimAt(npcid, Float:x, Float:y, Float:z, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
-native FCNPC_AimAtPlayer(npcid, playerid, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_x = 0.0, Float:offset_y = 0.0, Float:offset_z = 0.0, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
+native FCNPC_AimAt(npcid, Float:x, Float:y, Float:z, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween = FCNPC_SHOOT_CHECK_ALL);
+native FCNPC_AimAtPlayer(npcid, playerid, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_x = 0.0, Float:offset_y = 0.0, Float:offset_z = 0.0, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween = FCNPC_SHOOT_CHECK_ALL);
 native FCNPC_StopAim(npcid);
 native FCNPC_MeleeAttack(npcid, delay = -1, bool:fightstyle = false);
 native FCNPC_StopAttack(npcid);
@@ -252,7 +263,7 @@ native bool:FCNPC_IsAimingAtPlayer(npcid, playerid);
 native FCNPC_GetAimingPlayer(npcid);
 native bool:FCNPC_IsShooting(npcid);
 native bool:FCNPC_IsReloading(npcid);
-native FCNPC_TriggerWeaponShot(npcid, weaponid, hittype, hitid, Float:x, Float:y, Float:z, bool:ishit = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
+native FCNPC_TriggerWeaponShot(npcid, weaponid, hittype, hitid, Float:x, Float:y, Float:z, bool:ishit = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween = FCNPC_SHOOT_CHECK_ALL);
 
 native FCNPC_EnterVehicle(npcid, vehicleid, seatid, type = FCNPC_MOVE_TYPE_WALK);
 native FCNPC_ExitVehicle(npcid);

--- a/sampsvr_files/FCNPC.inc
+++ b/sampsvr_files/FCNPC.inc
@@ -25,6 +25,17 @@ public FCNPC_IncludeVersion = FCNPC_INCLUDE_VERSION;
 #endif
 
 // Definitions
+#define FCNPC_SHOOT_CHECK_NONE           (0)
+#define FCNPC_SHOOT_CHECK_PLAYER         (1)
+#define FCNPC_SHOOT_CHECK_NPC            (2)
+#define FCNPC_SHOOT_CHECK_ACTOR          (4)
+#define FCNPC_SHOOT_CHECK_VEHICLE        (8)
+#define FCNPC_SHOOT_CHECK_OBJECT         (16)
+#define FCNPC_SHOOT_CHECK_POBJECT_ORIG   (32)
+#define FCNPC_SHOOT_CHECK_POBJECT_TARG   (64)
+#define FCNPC_SHOOT_CHECK_MAP            (128)
+#define FCNPC_SHOOT_CHECK_ALL            (255)
+
 #define FCNPC_MOVE_TYPE_AUTO       (-1)
 #define FCNPC_MOVE_TYPE_WALK       (0)
 #define FCNPC_MOVE_TYPE_RUN        (1)
@@ -197,8 +208,8 @@ native bool:FCNPC_IsMoving(npcid);
 native bool:FCNPC_IsMovingAtPlayer(npcid, playerid);
 native FCNPC_GetDestinationPoint(npcid, &Float:x, &Float:y, &Float:z);
 
-native FCNPC_AimAt(npcid, Float:x, Float:y, Float:z, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
-native FCNPC_AimAtPlayer(npcid, playerid, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_x = 0.0, Float:offset_y = 0.0, Float:offset_z = 0.0, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
+native FCNPC_AimAt(npcid, Float:x, Float:y, Float:z, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween = FCNPC_SHOOT_CHECK_ALL);
+native FCNPC_AimAtPlayer(npcid, playerid, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_x = 0.0, Float:offset_y = 0.0, Float:offset_z = 0.0, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween = FCNPC_SHOOT_CHECK_ALL);
 native FCNPC_StopAim(npcid);
 native FCNPC_MeleeAttack(npcid, delay = -1, bool:fightstyle = false);
 native FCNPC_StopAttack(npcid);
@@ -208,7 +219,7 @@ native bool:FCNPC_IsAimingAtPlayer(npcid, playerid);
 native FCNPC_GetAimingPlayer(npcid);
 native bool:FCNPC_IsShooting(npcid);
 native bool:FCNPC_IsReloading(npcid);
-native FCNPC_TriggerWeaponShot(npcid, weaponid, hittype, hitid, Float:x, Float:y, Float:z, bool:ishit = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
+native FCNPC_TriggerWeaponShot(npcid, weaponid, hittype, hitid, Float:x, Float:y, Float:z, bool:ishit = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween = FCNPC_SHOOT_CHECK_ALL);
 
 native FCNPC_EnterVehicle(npcid, vehicleid, seatid, type = FCNPC_MOVE_TYPE_WALK);
 native FCNPC_ExitVehicle(npcid);

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -272,18 +272,16 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 	// Create the target SendBullet structure
 	CBulletSyncData bulletSyncDataTarget;
-	if (bIsHit) {
-		bulletSyncDataTarget.wHitID = wHitId;
-		bulletSyncDataTarget.byteHitType = byteHitType;
-	}
-	else {
-		bulletSyncDataTarget.wHitID = INVALID_PLAYER_ID;
-		bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
-	}
+	bulletSyncDataTarget.wHitID = wHitId;
+	bulletSyncDataTarget.byteHitType = byteHitType;
 	bulletSyncDataTarget.byteWeaponID = byteWeaponId;
-	bulletSyncDataTarget.vecCenterOfHit = CVector();
 	bulletSyncDataTarget.vecHitOrigin = vecOrigin;
 	bulletSyncDataTarget.vecHitTarget = vecPoint;
+	bulletSyncDataTarget.vecCenterOfHit = CVector();
+	if (!bIsHit) {
+		bulletSyncDataTarget.wHitID = 0xFFFF; // Using 0xFFFF instead of INVALID_PLAYER_ID, because the hitId is not necessarily a player
+		bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
+	}
 
 	// Find player in vecPoint
 	if (bIsHit && bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_NONE) {

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -297,7 +297,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 	// If something is in between the origin and the target, make that something the target
 	if (bulletSyncDataInBetween.wHitID != 0xFFFF) {
-		bulletSyncDataTarget = bulletSyncDataInBetween; //TODO check if struct copying works (deep copy or shallow copy?)
+		bulletSyncDataTarget = bulletSyncDataInBetween;
 	}
 
 	// Get center of hit

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -285,7 +285,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 	// Check if something is in between the origin and the target
 	/*BYTE byteClosestEntityHitType = BULLET_HIT_TYPE_NONE;
-	WORD wClosestEntity = GetClosestEntityInBetween(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, byteClosestEntityHitType, wPlayerId, bulletSyncDataTarget.wHitID);
+	WORD wClosestEntity = GetClosestEntityInBetween(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataTarget.byteWeaponID, byteClosestEntityHitType, wPlayerId, bulletSyncDataTarget.wHitID);
 	if (wClosestEntity != 0xFFFF) {
 		bulletSyncDataTarget.wHitID = wClosestEntity;
 		bulletSyncDataTarget.byteHitType = byteClosestEntityHitType;
@@ -371,14 +371,14 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	}
 }
 
-WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE &byteHitType, WORD wPlayerId, WORD wTargetId)
+WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, BYTE &byteHitType, WORD wPlayerId, WORD wTargetId)
 {
 	WORD wClosestEntity = 0xFFFF;
 	float fClosestEntityDistance = 0.0;
 
 	// Check if a player is in between the origin and the target
 	float fClosestPlayerDistance = 0.0;
-	WORD wClosestPlayer = GetClosestPlayerInBetween(vecHitOrigin, vecHitTarget, fClosestPlayerDistance, wPlayerId, wTargetId);
+	WORD wClosestPlayer = GetClosestPlayerInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestPlayerDistance, wPlayerId, wTargetId);
 	if (wClosestPlayer != INVALID_PLAYER_ID && (wClosestEntity == 0xFFFF || fClosestPlayerDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_PLAYER;
 		fClosestEntityDistance = fClosestPlayerDistance;
@@ -387,7 +387,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 
 	// Check if an NPC is in between the origin and the target
 	float fClosestNPCDistance = 0.0;
-	WORD wClosestNPC = GetClosestNPCInBetween(vecHitOrigin, vecHitTarget, fClosestNPCDistance, wPlayerId, wTargetId); //Separate function in case we need to handle NPCs differently form players in the future
+	WORD wClosestNPC = GetClosestNPCInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestNPCDistance, wPlayerId, wTargetId); //Separate function in case we need to handle NPCs differently form players in the future
 	if (wClosestNPC != INVALID_PLAYER_ID && (wClosestEntity == 0xFFFF || fClosestNPCDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_PLAYER;
 		fClosestEntityDistance = fClosestNPCDistance;
@@ -396,7 +396,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 
 	// Check if an actor is in between the origin and the target
 	float fClosestActorDistance = 0.0;
-	WORD wClosestActor = GetClosestActorInBetween(vecHitOrigin, vecHitTarget, fClosestActorDistance);
+	WORD wClosestActor = GetClosestActorInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestActorDistance);
 	if (wClosestActor != INVALID_ACTOR_ID && (wClosestEntity == 0xFFFF || fClosestActorDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_NONE; //Actors don't have a hit type, this is conform with the SA-MP native OnPlayerWeaponShot
 		fClosestEntityDistance = fClosestActorDistance;
@@ -405,7 +405,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 
 	// Check if a vehicle is in between the origin and the target
 	float fClosestVehicleDistance = 0.0;
-	WORD wClosestVehicle = GetClosestVehicleInBetween(vecHitOrigin, vecHitTarget, fClosestVehicleDistance);
+	WORD wClosestVehicle = GetClosestVehicleInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestVehicleDistance);
 	if (wClosestVehicle != INVALID_VEHICLE_ID && (wClosestEntity == 0xFFFF || fClosestVehicleDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_VEHICLE;
 		fClosestEntityDistance = fClosestVehicleDistance;
@@ -414,7 +414,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 
 	// Check if an object is in between the origin and the target
 	float fClosestObjectDistance = 0.0;
-	WORD wClosestObject = GetClosestObjectInBetween(vecHitOrigin, vecHitTarget, fClosestObjectDistance);
+	WORD wClosestObject = GetClosestObjectInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestObjectDistance);
 	if (wClosestObject != INVALID_OBJECT_ID && (wClosestEntity == 0xFFFF || fClosestObjectDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_OBJECT;
 		fClosestEntityDistance = fClosestObjectDistance;
@@ -423,7 +423,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 
 	// Check if a player object is in between the origin and the target
 	float fClosestPlayerObjectDistance = 0.0;
-	WORD wClosestPlayerObject = GetClosestPlayerObjectInBetween(vecHitOrigin, vecHitTarget, fClosestPlayerObjectDistance, wPlayerId);
+	WORD wClosestPlayerObject = GetClosestPlayerObjectInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestPlayerObjectDistance, wPlayerId);
 	if (wClosestPlayerObject != INVALID_OBJECT_ID && (wClosestEntity == 0xFFFF || fClosestPlayerObjectDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_PLAYER_OBJECT;
 		fClosestEntityDistance = fClosestPlayerObjectDistance;
@@ -432,7 +432,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 
 	//Check if a map point is in between the origin and the target
 	float fClosestMapPointDistance = 0.0;
-	WORD wClosestMapPoint = GetClosestMapPointInBetween(vecHitOrigin, vecHitTarget, fClosestMapPointDistance);
+	WORD wClosestMapPoint = GetClosestMapPointInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestMapPointDistance);
 	if (wClosestMapPoint != 0 && (wClosestEntity == 0xFFFF || fClosestMapPointDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_OBJECT;
 		fClosestEntityDistance = fClosestMapPointDistance;
@@ -442,7 +442,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 	return wClosestEntity;
 }
 
-WORD CFunctions::GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId, WORD wTargetId)
+WORD CFunctions::GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId)
 {
 	WORD wClosestPlayer = INVALID_PLAYER_ID;
 
@@ -462,7 +462,7 @@ WORD CFunctions::GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CV
 
 		// Is the player in the damage range
 		float fPlayerDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pPlayer->vecPosition);
-		if (fPlayerDistance > MAX_DAMAGE_DISTANCE) {
+		if (fPlayerDistance > CWeaponInfo::GetDefaultInfo(byteWeaponID).fRange) {
 			continue;
 		}
 
@@ -476,7 +476,7 @@ WORD CFunctions::GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CV
 	return wClosestPlayer;
 }
 
-WORD CFunctions::GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId, WORD wTargetId)
+WORD CFunctions::GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId)
 {
 	WORD wClosestNPC = INVALID_PLAYER_ID;
 
@@ -496,7 +496,7 @@ WORD CFunctions::GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVect
 
 		// Is the NPC in the damage range
 		float fNPCDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pNPC->vecPosition);
-		if (fNPCDistance > MAX_DAMAGE_DISTANCE) {
+		if (fNPCDistance > CWeaponInfo::GetDefaultInfo(byteWeaponID).fRange) {
 			continue;
 		}
 
@@ -510,7 +510,7 @@ WORD CFunctions::GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVect
 	return wClosestNPC;
 }
 
-WORD CFunctions::GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance)
+WORD CFunctions::GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance)
 {
 	WORD wClosestActor = INVALID_ACTOR_ID;
 
@@ -530,7 +530,7 @@ WORD CFunctions::GetClosestActorInBetween(const CVector &vecHitOrigin, const CVe
 
 		// Is the actor in the damage range
 		float fActorDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pActor->vecPosition);
-		if (fActorDistance > MAX_DAMAGE_DISTANCE) {
+		if (fActorDistance > CWeaponInfo::GetDefaultInfo(byteWeaponID).fRange) {
 			continue;
 		}
 
@@ -544,7 +544,7 @@ WORD CFunctions::GetClosestActorInBetween(const CVector &vecHitOrigin, const CVe
 	return wClosestActor;
 }
 
-WORD CFunctions::GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance)
+WORD CFunctions::GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance)
 {
 	WORD wClosestVehicle = INVALID_VEHICLE_ID;
 
@@ -564,7 +564,7 @@ WORD CFunctions::GetClosestVehicleInBetween(const CVector &vecHitOrigin, const C
 
 		// Is the vehicle in the damage range
 		float fVehicleDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pVehicle->vecPosition);
-		if (fVehicleDistance > MAX_DAMAGE_DISTANCE) {
+		if (fVehicleDistance > CWeaponInfo::GetDefaultInfo(byteWeaponID).fRange) {
 			continue;
 		}
 
@@ -578,7 +578,7 @@ WORD CFunctions::GetClosestVehicleInBetween(const CVector &vecHitOrigin, const C
 	return wClosestVehicle;
 }
 
-WORD CFunctions::GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance)
+WORD CFunctions::GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance)
 {
 	WORD wClosestObject = INVALID_OBJECT_ID;
 
@@ -598,7 +598,7 @@ WORD CFunctions::GetClosestObjectInBetween(const CVector &vecHitOrigin, const CV
 
 		// Is the object in the damage range
 		float fObjectDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pObject->matWorld.pos);
-		if (fObjectDistance > MAX_DAMAGE_DISTANCE) {
+		if (fObjectDistance > CWeaponInfo::GetDefaultInfo(byteWeaponID).fRange) {
 			continue;
 		}
 
@@ -612,7 +612,7 @@ WORD CFunctions::GetClosestObjectInBetween(const CVector &vecHitOrigin, const CV
 	return wClosestObject;
 }
 
-WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId)
+WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId)
 {
 	WORD wClosestPlayerObject = INVALID_OBJECT_ID;
 
@@ -632,7 +632,7 @@ WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, co
 
 		// Is the player object in the damage range
 		float fPlayerObjectDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pPlayerObject->matWorld.pos);
-		if (fPlayerObjectDistance > MAX_DAMAGE_DISTANCE) {
+		if (fPlayerObjectDistance > CWeaponInfo::GetDefaultInfo(byteWeaponID).fRange) {
 			continue;
 		}
 
@@ -646,7 +646,7 @@ WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, co
 	return wClosestPlayerObject;
 }
 
-WORD CFunctions::GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance)
+WORD CFunctions::GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance)
 {
 	//TODO
 	//- GetClosestPlayerObjectInBetween only checks for player objects of the shooter, not the target
@@ -654,7 +654,6 @@ WORD CFunctions::GetClosestMapPointInBetween(const CVector &vecHitOrigin, const 
 	//- improve GetClosestObjectInBetween and GetClosestPlayerObjectInBetween when ColAndreas is enabled, otherwise fall back on existing code
 	//- add FCNPC_AimAt, FCNPC_AimAtPlayer, FCNPC_TriggerWeaponShot extra parameter that disables inbetween checking for certain types (bit masking)
 	//- add FCNPC_AimAt, FCNPC_AimAtPlayer, FCNPC_TriggerWeaponShot extra parameter with same effect as MOVE_MODE_X, called SHOOT_MODE_X
-	//- add SP weapon ranges in CWeaponInfo and use these ranges instead of MAX_DAMAGE_DISTANCE, see column 'weaponRange' in weapon.dat
 	//- add custom hit radii for each entity type and use these ranges instead of MAX_HIT_RADIUS
 
 	return 0;

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -423,7 +423,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 
 	// Check if a player object is in between the origin and the target
 	float fClosestPlayerObjectDistance = 0.0;
-	WORD wClosestPlayerObject = GetClosestPlayerObjectInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestPlayerObjectDistance, wPlayerId);
+	WORD wClosestPlayerObject = GetClosestPlayerObjectInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestPlayerObjectDistance, wPlayerId); //Only checks for player objects of the shooter, not the target
 	if (wClosestPlayerObject != INVALID_OBJECT_ID && (wClosestEntity == 0xFFFF || fClosestPlayerObjectDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_PLAYER_OBJECT;
 		fClosestEntityDistance = fClosestPlayerObjectDistance;
@@ -616,7 +616,7 @@ WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, co
 {
 	WORD wClosestPlayerObject = INVALID_OBJECT_ID;
 
-	// Loop through all the player objects
+	// Loop through all the player objects of the shooter
 	for (WORD i = 1; i < MAX_OBJECTS; i++) { //Player object IDs start at 1
 
 		// Validate the player object
@@ -649,7 +649,6 @@ WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, co
 WORD CFunctions::GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance)
 {
 	//TODO
-	//- GetClosestPlayerObjectInBetween only checks for player objects of the shooter, not the target
 	//- implement GetClosestMapPointInBetween when ColAndreas is enabled, otherwise return nothing (0)
 	//- improve GetClosestObjectInBetween and GetClosestPlayerObjectInBetween when ColAndreas is enabled, otherwise fall back on existing code
 	//- add FCNPC_AimAt, FCNPC_AimAtPlayer, FCNPC_TriggerWeaponShot extra parameter that disables inbetween checking for certain types (bit masking)

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -323,7 +323,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		}
 		break;
 	case BULLET_HIT_TYPE_OBJECT:
-		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
+		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { //Object IDs start at 1
 			CObject *pObject = pNetGame->pObjectPool->pObjects[bulletSyncDataTarget.wHitID];
 			if (pObject) {
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pObject->matWorld.pos);
@@ -332,7 +332,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		}
 		break;
 	case BULLET_HIT_TYPE_PLAYER_OBJECT:
-		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
+		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { //Player object IDs start at 1
 			CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncDataTarget.wHitID];
 			if (pPlayerObject) {
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayerObject->matWorld.pos);
@@ -583,7 +583,7 @@ WORD CFunctions::GetClosestObjectInBetween(const CVector &vecHitOrigin, const CV
 	WORD wClosestObject = INVALID_OBJECT_ID;
 
 	// Loop through all the objects
-	for (WORD i = 0; i < MAX_OBJECTS; i++) {
+	for (WORD i = 1; i < MAX_OBJECTS; i++) { //Object IDs start at 1
 
 		// Validate the object
 		CObject *pObject = pNetGame->pObjectPool->pObjects[i];
@@ -617,7 +617,7 @@ WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, co
 	WORD wClosestPlayerObject = INVALID_OBJECT_ID;
 
 	// Loop through all the player objects
-	for (WORD i = 0; i < MAX_OBJECTS; i++) {
+	for (WORD i = 1; i < MAX_OBJECTS; i++) { //Player object IDs start at 1
 
 		// Validate the player object
 		CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][i];

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -283,16 +283,16 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
 	}
 
-	// Is something in between the origin and the target
+	// Create the inBetween SendBullet structure
 	CBulletSyncData bulletSyncDataInBetween;
 	bulletSyncDataInBetween.byteWeaponID = bulletSyncDataTarget.byteWeaponID;
 	bulletSyncDataInBetween.vecHitOrigin = bulletSyncDataTarget.vecHitOrigin;
 	bulletSyncDataInBetween.vecHitTarget = CVector();
-	bulletSyncDataInBetween.vecCenterOfHit = CVector();
-	bulletSyncDataTarget.wHitID = 0xFFFF;
-	bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
+	bulletSyncDataInBetween.vecCenterOfHit = bulletSyncDataInBetween.vecHitTarget;
+	bulletSyncDataInBetween.wHitID = 0xFFFF;
+	bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_NONE;
 
-	/*
+	// Check if something is in between the origin and the target
 	for (WORD i = 0; i <= pNetGame->pPlayerPool->dwPlayerPoolSize; i++) {
 		if (!pServer->GetPlayerManager()->IsPlayerConnected(i) || wPlayerId == i) {
 			continue;
@@ -307,13 +307,18 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		bool bIsPlayerInDamageRange = bIsPlayerOnRay && CMath::GetDistanceBetween3DPoints(bulletSyncDataTarget.vecHitOrigin, pPlayer->vecPosition) < MAX_DAMAGE_DISTANCE;
 
 		if (bIsPlayerOnRay && bIsPlayerInDamageRange) {
-			bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_PLAYER;
-			bulletSyncDataTarget.wHitID = i;
-			bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition);
-			break;
+			bulletSyncDataInBetween.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition);
+			bulletSyncDataInBetween.vecCenterOfHit = bulletSyncDataInBetween.vecHitTarget;
+			bulletSyncDataInBetween.wHitID = i;
+			bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_PLAYER;
+			break; //TODO get closest player, not player with lowest id
 		}
 	}
-	*/
+
+	// If something is in between the origin and the target, make that something the target
+	if (bulletSyncDataInBetween.wHitID != 0xFFFF) {
+		bulletSyncDataTarget = bulletSyncDataInBetween; //TODO check if struct copying works (deep copy or shallow copy?)
+	}
 
 	// Get center of hit
 	switch (bulletSyncDataTarget.byteHitType) {

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -284,9 +284,9 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	}
 
 	// Check if something is in between the origin and the target
-	/*BYTE byteClosestEntityHitType = BULLET_HIT_TYPE_NONE;
+	BYTE byteClosestEntityHitType = BULLET_HIT_TYPE_NONE;
 	WORD wClosestEntity = GetClosestEntityInBetween(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataTarget.byteWeaponID, byteClosestEntityHitType, wPlayerId, bulletSyncDataTarget.wHitID);
-	if (wClosestEntity != 0xFFFF) {
+	/*if (wClosestEntity != 0xFFFF) {
 		bulletSyncDataTarget.wHitID = wClosestEntity;
 		bulletSyncDataTarget.byteHitType = byteClosestEntityHitType;
 	}*/
@@ -654,7 +654,6 @@ WORD CFunctions::GetClosestMapPointInBetween(const CVector &vecHitOrigin, const 
 	//- improve GetClosestObjectInBetween and GetClosestPlayerObjectInBetween when ColAndreas is enabled, otherwise fall back on existing code
 	//- add FCNPC_AimAt, FCNPC_AimAtPlayer, FCNPC_TriggerWeaponShot extra parameter that disables inbetween checking for certain types (bit masking)
 	//- add FCNPC_AimAt, FCNPC_AimAtPlayer, FCNPC_TriggerWeaponShot extra parameter with same effect as MOVE_MODE_X, called SHOOT_MODE_X
-	//- add custom hit radii for each entity type and use these ranges instead of MAX_HIT_RADIUS
 
 	return 0;
 }

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -281,7 +281,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 	// If the shooter misses his shot
 	if (!bIsHit) {
-		logprintf("TARGET MISSED");
+		// logprintf("TARGET MISSED");
 		bulletSyncDataTarget.wHitID = 0xFFFF; // Using 0xFFFF instead of INVALID_PLAYER_ID, because the hitId is not necessarily a player
 		bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
 	}
@@ -289,7 +289,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	// If the target is not in range
 	float fTargetDistance = CMath::GetDistanceBetween3DPoints(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget);
 	if (fTargetDistance > CWeaponInfo::GetDefaultInfo(bulletSyncDataTarget.byteWeaponID).fRange) {
-		logprintf("TARGET OUT OF RANGE");
+		// logprintf("TARGET OUT OF RANGE");
 		bulletSyncDataTarget.wHitID = 0xFFFF;
 		bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
 	}
@@ -300,7 +300,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	CVector vecHitMap = bulletSyncDataTarget.vecHitTarget;
 	WORD wClosestEntity = GetClosestEntityInBetween(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataTarget.byteWeaponID, fTargetDistance, byteClosestEntityHitType, wPlayerObjectOwnerId, vecHitMap, checkInBetween, wPlayerId, wHitId); // Pass original hit ID to correctly handle missed or out of range shots!
 	if (wClosestEntity != 0xFFFF) {
-		logprintf("SOMETHING IN BETWEEN SHOOTER AND TARGET");
+		// logprintf("SOMETHING IN BETWEEN SHOOTER AND TARGET");
 		bulletSyncDataTarget.wHitID = wClosestEntity;
 		bulletSyncDataTarget.byteHitType = byteClosestEntityHitType;
 	}
@@ -311,17 +311,17 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_ACTORS) { // Actors don't have a hit type, this is conform with the SA-MP callback OnPlayerWeaponShot
 			CActor *pActor = pNetGame->pActorPool->pActor[bulletSyncDataTarget.wHitID];
 			if (pActor) {
-				logprintf("HIT ACTOR");
+				// logprintf("HIT ACTOR");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pActor->vecPosition);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget; // When actor is hit use the actor collision position, this is conform with the SA-MP callback OnPlayerWeaponShot
 			}
 		}
 		else if (bulletSyncDataTarget.wHitID == -1) { // Hit map
-			logprintf("HIT MAP");
+			// logprintf("HIT MAP");
 			bulletSyncDataTarget.vecCenterOfHit = vecHitMap; // When map is hit use the object collision position, this is conform with the SA-MP callback OnPlayerWeaponShot
 		}
 		else { // Hit nothing
-			logprintf("HIT NOTHING");
+			// logprintf("HIT NOTHING");
 			bulletSyncDataTarget.vecCenterOfHit = CVector(); // When nothing is hit use 0.0, this is conform with the SA-MP callback OnPlayerWeaponShot
 		}
 		break;
@@ -330,12 +330,12 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 			CPlayer *pPlayer = pNetGame->pPlayerPool->pPlayer[bulletSyncDataTarget.wHitID];
 			if (pPlayer) {
 				if (!pServer->GetPlayerManager()->IsNPC(bulletSyncDataTarget.wHitID)) { // Separate code for players and NPCs, in case we need to handle them differently in the future
-					logprintf("HIT PLAYER");
+					// logprintf("HIT PLAYER");
 					bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition);
 					bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayer->vecPosition;
 				}
 				else {
-					logprintf("HIT NPC");
+					// logprintf("HIT NPC");
 					bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition);
 					bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayer->vecPosition;
 				}
@@ -346,7 +346,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_VEHICLES) { // Vehicle IDs start at 1
 			CVehicle *pVehicle = pNetGame->pVehiclePool->pVehicle[bulletSyncDataTarget.wHitID];
 			if (pVehicle) {
-				logprintf("HIT VEHICLE");
+				// logprintf("HIT VEHICLE");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pVehicle->vecPosition);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pVehicle->vecPosition;
 			}
@@ -356,7 +356,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { // Object IDs start at 1
 			CObject *pObject = pNetGame->pObjectPool->pObjects[bulletSyncDataTarget.wHitID];
 			if (pObject) {
-				logprintf("HIT OBJECT");
+				// logprintf("HIT OBJECT");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pObject->matWorld.pos);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pObject->matWorld.pos;
 			}
@@ -367,7 +367,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 			if (wPlayerObjectOwnerId == wPlayerId) { // Handles player objects of the shooter
 				CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncDataTarget.wHitID];
 				if (pPlayerObject) {
-					logprintf("HIT PLAYER OBJECT SHOOTER");
+					// logprintf("HIT PLAYER OBJECT SHOOTER");
 					bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayerObject->matWorld.pos);
 					bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayerObject->matWorld.pos;
 				}
@@ -376,7 +376,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 				if (pServer->GetPlayerManager()->IsPlayerConnected(wHitId)) {
 					CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wHitId][bulletSyncDataTarget.wHitID]; // Use original hit ID to correctly handle target player objects!
 					if (pPlayerObject) {
-						logprintf("HIT PLAYER OBJECT TARGET");
+						// logprintf("HIT PLAYER OBJECT TARGET");
 						bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayerObject->matWorld.pos);
 						bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayerObject->matWorld.pos;
 					}
@@ -386,7 +386,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 				if (!pServer->GetPlayerManager()->IsNPC(wPlayerObjectOwnerId)) { // Handles player objects of the closestPlayer
 					CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerObjectOwnerId][bulletSyncDataTarget.wHitID];
 					if (pPlayerObject) {
-						logprintf("HIT PLAYER OBJECT CLOSESTPLAYER");
+						// logprintf("HIT PLAYER OBJECT CLOSESTPLAYER");
 						bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayerObject->matWorld.pos);
 						bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayerObject->matWorld.pos;
 					}
@@ -394,7 +394,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 				else { // Handles player objects of the closestNPC
 					CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerObjectOwnerId][bulletSyncDataTarget.wHitID];
 					if (pPlayerObject) {
-						logprintf("HIT PLAYER OBJECT CLOSESTNPC");
+						// logprintf("HIT PLAYER OBJECT CLOSESTNPC");
 						bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayerObject->matWorld.pos);
 						bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayerObject->matWorld.pos;
 					}
@@ -409,7 +409,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 	// Call FCNPC_OnWeaponShot
 	int send = CCallbackManager::OnWeaponShot(wPlayerId, bulletSyncDataTarget.byteWeaponID, bulletSyncDataTarget.byteHitType, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecCenterOfHit);
-	logprintf("TYPE %d, ID %d, %.2f, %.2f, %.2f", bulletSyncDataTarget.byteHitType, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecCenterOfHit.fX, bulletSyncDataTarget.vecCenterOfHit.fY, bulletSyncDataTarget.vecCenterOfHit.fZ);
+	// logprintf("TYPE %d, ID %d, %.2f, %.2f, %.2f", bulletSyncDataTarget.byteHitType, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecCenterOfHit.fX, bulletSyncDataTarget.vecCenterOfHit.fY, bulletSyncDataTarget.vecCenterOfHit.fZ);
 
 	// Deal damage to the target NPC if the target is an NPC
 	if (send != 0) {
@@ -421,7 +421,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 				pHitPlayerData->ProcessDamage(wPlayerId, sWeaponInfo.fDamage, bulletSyncDataTarget.byteWeaponID, BODY_PART_TORSO);
 				CCallbackManager::OnGiveDamage(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.byteWeaponID, BODY_PART_TORSO, sWeaponInfo.fDamage);
-				logprintf("DAMAGE NPC");
+				// logprintf("DAMAGE NPC");
 			}
 		}
 

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -293,7 +293,14 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_NONE;
 
 	// Check if something is in between the origin and the target
+	/*
 	GetClosestPlayerInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
+	GetClosestNPCInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
+	GetClosestActorInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
+	GetClosestVehicleInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
+	GetClosestObjectInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
+	GetClosestPlayerObjectInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
+	*/
 
 	// If something is in between the origin and the target, make that something the target
 	if (bulletSyncDataInBetween.wHitID != 0xFFFF) {
@@ -301,19 +308,26 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	}
 
 	// Get center of hit
+	/*
 	switch (bulletSyncDataTarget.byteHitType) {
 	case BULLET_HIT_TYPE_NONE:
+		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_ACTORS) { //Actors don't have a hit type
+			CActor *pActor = pNetGame->pActorPool->pActor[bulletSyncDataTarget.wHitID];
+			if (pActor) {
+				bulletSyncDataTarget.vecCenterOfHit -= pActor->vecPosition;
+			}
+		}
 		break;
 	case BULLET_HIT_TYPE_PLAYER:
 		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_PLAYERS) {
-			CPlayer *pHitPlayerData = pNetGame->pPlayerPool->pPlayer[bulletSyncDataTarget.wHitID];
-			if (pHitPlayerData) {
-				bulletSyncDataTarget.vecCenterOfHit -= pHitPlayerData->vecPosition;
+			CPlayer *pPlayer = pNetGame->pPlayerPool->pPlayer[bulletSyncDataTarget.wHitID];
+			if (pPlayer) {
+				bulletSyncDataTarget.vecCenterOfHit -= pPlayer->vecPosition;
 			}
 		}
 		break;
 	case BULLET_HIT_TYPE_VEHICLE:
-		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_VEHICLES) {
+		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_VEHICLES) { //Vehicle IDs start at 1
 			CVehicle *pVehicle = pNetGame->pVehiclePool->pVehicle[bulletSyncDataTarget.wHitID];
 			if (pVehicle) {
 				bulletSyncDataTarget.vecCenterOfHit -= pVehicle->vecPosition;
@@ -321,7 +335,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		}
 		break;
 	case BULLET_HIT_TYPE_OBJECT:
-		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
+		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
 			CObject *pObject = pNetGame->pObjectPool->pObjects[bulletSyncDataTarget.wHitID];
 			if (pObject) {
 				bulletSyncDataTarget.vecCenterOfHit -= pObject->matWorld.pos;
@@ -329,14 +343,15 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		}
 		break;
 	case BULLET_HIT_TYPE_PLAYER_OBJECT:
-		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
-			CObject *pObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncDataTarget.wHitID];
-			if (pObject) {
-				bulletSyncDataTarget.vecCenterOfHit -= pObject->matWorld.pos;
+		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
+			CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncDataTarget.wHitID];
+			if (pPlayerObject) {
+				bulletSyncDataTarget.vecCenterOfHit -= pPlayerObject->matWorld.pos;
 			}
 		}
 		break;
 	}
+	*/
 
 	// Update bullet sync data
 	pPlayerData->SetBulletSync(&bulletSyncDataTarget);
@@ -367,7 +382,8 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	}
 }
 
-void CFunctions::GetClosestPlayerInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween) {
+void CFunctions::GetClosestPlayerInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween)
+{
 	WORD wClosestPlayer = INVALID_PLAYER_ID;
 	float fClosestPlayerDistance = 0.0;
 
@@ -399,6 +415,191 @@ void CFunctions::GetClosestPlayerInBetween(WORD wPlayerId, WORD wTargetId, const
 			bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_PLAYER;
 			fClosestPlayerDistance = fPlayerDistance;
 			wClosestPlayer = i;
+		}
+	}
+}
+
+void CFunctions::GetClosestNPCInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween)
+{
+	WORD wClosestNPC = INVALID_PLAYER_ID;
+	float fClosestNPCDistance = 0.0;
+
+	// Loop through all the NPCs
+	for (WORD i = 0; i <= pNetGame->pPlayerPool->dwPlayerPoolSize; i++) {
+
+		// Validate the NPC
+		CPlayer *pNPC = pNetGame->pPlayerPool->pPlayer[i];
+		if (wPlayerId == i || wTargetId == i || !pNPC || !pServer->GetPlayerManager()->IsNpcConnected(i)) {
+			continue;
+		}
+
+		// Is the NPC on the ray
+		if (CMath::GetDistanceFromRayToPoint(vecHitOrigin, vecHitTarget, pNPC->vecPosition) > MAX_HIT_RADIUS) {
+			continue;
+		}
+
+		// Is the NPC in the damage range
+		float fNPCDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pNPC->vecPosition);
+		if (fNPCDistance > MAX_DAMAGE_DISTANCE) {
+			continue;
+		}
+
+		// Is the NPC closer
+		if (wClosestNPC == INVALID_PLAYER_ID || fNPCDistance < fClosestNPCDistance) {
+			bulletSyncDataInBetween.vecHitTarget = CMath::GetNearestPointToRay(vecHitOrigin, vecHitTarget, pNPC->vecPosition);
+			bulletSyncDataInBetween.vecCenterOfHit = bulletSyncDataInBetween.vecHitTarget;
+			bulletSyncDataInBetween.wHitID = i;
+			bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_PLAYER;
+			fClosestNPCDistance = fNPCDistance;
+			wClosestNPC = i;
+		}
+	}
+}
+
+void CFunctions::GetClosestActorInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween)
+{
+	WORD wClosestActor = INVALID_ACTOR_ID;
+	float fClosestActorDistance = 0.0;
+
+	// Loop through all the actors
+	for (WORD i = 0; i <= pNetGame->pActorPool->dwActorPoolSize; i++) {
+
+		// Validate the actor
+		CActor *pActor = pNetGame->pActorPool->pActor[i];
+		if (!pActor || !pNetGame->pActorPool->bValidActor[i]) {
+			continue;
+		}
+
+		// Is the actor on the ray
+		if (CMath::GetDistanceFromRayToPoint(vecHitOrigin, vecHitTarget, pActor->vecPosition) > MAX_HIT_RADIUS) {
+			continue;
+		}
+
+		// Is the actor in the damage range
+		float fActorDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pActor->vecPosition);
+		if (fActorDistance > MAX_DAMAGE_DISTANCE) {
+			continue;
+		}
+
+		// Is the actor closer
+		if (wClosestActor == INVALID_ACTOR_ID || fActorDistance < fClosestActorDistance) {
+			bulletSyncDataInBetween.vecHitTarget = CMath::GetNearestPointToRay(vecHitOrigin, vecHitTarget, pActor->vecPosition);
+			bulletSyncDataInBetween.vecCenterOfHit = bulletSyncDataInBetween.vecHitTarget;
+			bulletSyncDataInBetween.wHitID = i;
+			bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_NONE; //Actors don't have a hit type
+			fClosestActorDistance = fActorDistance;
+			wClosestActor = i;
+		}
+	}
+}
+
+void CFunctions::GetClosestVehicleInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween)
+{
+	WORD wClosestVehicle = INVALID_VEHICLE_ID;
+	float fClosestVehicleDistance = 0.0;
+
+	// Loop through all the vehicles
+	for (WORD i = 1; i <= pNetGame->pVehiclePool->dwVehiclePoolSize; i++) { //Vehicle IDs start at 1
+
+		// Validate the vehicle
+		CVehicle *pVehicle = pNetGame->pVehiclePool->pVehicle[i];
+		if (!pVehicle) {
+			continue;
+		}
+
+		// Is the vehicle on the ray
+		if (CMath::GetDistanceFromRayToPoint(vecHitOrigin, vecHitTarget, pVehicle->vecPosition) > MAX_HIT_RADIUS) {
+			continue;
+		}
+
+		// Is the vehicle in the damage range
+		float fVehicleDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pVehicle->vecPosition);
+		if (fVehicleDistance > MAX_DAMAGE_DISTANCE) {
+			continue;
+		}
+
+		// Is the vehicle closer
+		if (wClosestVehicle == INVALID_VEHICLE_ID || fVehicleDistance < fClosestVehicleDistance) {
+			bulletSyncDataInBetween.vecHitTarget = CMath::GetNearestPointToRay(vecHitOrigin, vecHitTarget, pVehicle->vecPosition);
+			bulletSyncDataInBetween.vecCenterOfHit = bulletSyncDataInBetween.vecHitTarget;
+			bulletSyncDataInBetween.wHitID = i;
+			bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_VEHICLE;
+			fClosestVehicleDistance = fVehicleDistance;
+			wClosestVehicle = i;
+		}
+	}
+}
+
+void CFunctions::GetClosestObjectInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween)
+{
+	WORD wClosestObject = INVALID_OBJECT_ID;
+	float fClosestObjectDistance = 0.0;
+
+	// Loop through all the objects
+	for (WORD i = 0; i < MAX_OBJECTS; i++) {
+
+		// Validate the object
+		CObject *pObject = pNetGame->pObjectPool->pObjects[i];
+		if (!pObject) {
+			continue;
+		}
+
+		// Is the object on the ray
+		if (CMath::GetDistanceFromRayToPoint(vecHitOrigin, vecHitTarget, pObject->matWorld.pos) > MAX_HIT_RADIUS) {
+			continue;
+		}
+
+		// Is the object in the damage range
+		float fObjectDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pObject->matWorld.pos);
+		if (fObjectDistance > MAX_DAMAGE_DISTANCE) {
+			continue;
+		}
+
+		// Is the object closer
+		if (wClosestObject == INVALID_OBJECT_ID || fObjectDistance < fClosestObjectDistance) {
+			bulletSyncDataInBetween.vecHitTarget = CMath::GetNearestPointToRay(vecHitOrigin, vecHitTarget, pObject->matWorld.pos);
+			bulletSyncDataInBetween.vecCenterOfHit = bulletSyncDataInBetween.vecHitTarget;
+			bulletSyncDataInBetween.wHitID = i;
+			bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_OBJECT;
+			fClosestObjectDistance = fObjectDistance;
+			wClosestObject = i;
+		}
+	}
+}
+
+void CFunctions::GetClosestPlayerObjectInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween)
+{
+	WORD wClosestPlayerObject = INVALID_OBJECT_ID;
+	float fClosestPlayerObjectDistance = 0.0;
+
+	// Loop through all the player objects
+	for (WORD i = 0; i < MAX_OBJECTS; i++) {
+
+		// Validate the player object
+		CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][i];
+		if (!pPlayerObject) {
+			continue;
+		}
+
+		// Is the player object on the ray
+		if (CMath::GetDistanceFromRayToPoint(vecHitOrigin, vecHitTarget, pPlayerObject->matWorld.pos) > MAX_HIT_RADIUS) {
+			continue;
+		}
+
+		// Is the player object in the damage range
+		float fPlayerObjectDistance = CMath::GetDistanceBetween3DPoints(vecHitOrigin, pPlayerObject->matWorld.pos);
+		if (fPlayerObjectDistance > MAX_DAMAGE_DISTANCE) {
+			continue;
+		}
+
+		// Is the player object closer
+		if (wClosestPlayerObject == INVALID_OBJECT_ID || fPlayerObjectDistance < fClosestPlayerObjectDistance) {
+			bulletSyncDataInBetween.vecHitTarget = CMath::GetNearestPointToRay(vecHitOrigin, vecHitTarget, pPlayerObject->matWorld.pos);
+			bulletSyncDataInBetween.vecCenterOfHit = bulletSyncDataInBetween.vecHitTarget;
+			bulletSyncDataInBetween.wHitID = i;
+			bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_PLAYER_OBJECT;
+			fClosestPlayerObjectDistance = fPlayerObjectDistance;
+			wClosestPlayerObject = i;
 		}
 	}
 }

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -313,6 +313,10 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pActor->vecPosition;
 			}
 		}
+		else if (bulletSyncDataTarget.wHitID == -1) { // Hit map
+			logprintf("HIT MAP");
+			bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget; // When map is hit use the target position, this is conform with the SA-MP callback OnPlayerWeaponShot
+		}
 		else { // Hit nothing
 			logprintf("HIT NOTHING");
 			bulletSyncDataTarget.vecCenterOfHit = CVector(); // When nothing is hit use 0.0, this is conform with the SA-MP callback OnPlayerWeaponShot
@@ -493,7 +497,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 		float fClosestMapPointDistance = 0.0;
 		WORD wClosestMapPoint = GetClosestMapPointInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestMapPointDistance);
 		if (wClosestMapPoint != 0 && (wClosestEntity == 0xFFFF || fClosestMapPointDistance < fClosestEntityDistance)) {
-			byteHitType = BULLET_HIT_TYPE_OBJECT;
+			byteHitType = BULLET_HIT_TYPE_NONE;
 			fClosestEntityDistance = fClosestMapPointDistance;
 			wClosestEntity = wClosestMapPoint;
 		}
@@ -713,9 +717,24 @@ WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, co
 WORD CFunctions::GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance)
 {
 	//TODO
-	//- implement GetClosestMapPointInBetween when ColAndreas is enabled, otherwise return nothing (0)
-	//- improve GetClosestObjectInBetween and GetClosestPlayerObjectInBetween when ColAndreas is enabled, otherwise fall back on existing code
-	//- add FCNPC_AimAt, FCNPC_AimAtPlayer, FCNPC_TriggerWeaponShot extra parameter with same effect as MOVE_MODE_X, called SHOOT_MODE_X
+	//1) GetClosestMapPointInBetween:
+	//- implement when ColAndreas is enabled, otherwise return nothing (0).
+	//- currently the code handles map points when the hit type is BULLET_HIT_TYPE_NONE and the hit ID is -1.
+	//- this function should specificly check for map points only, not for global objects or custom objects!
+	//- keep in mind that bullets can penetrate water and still deal damage.
+
+	//2) GetClosestObjectInBetween:
+	//- improve when ColAndreas is enabled, otherwise fall back on existing code.
+	//- this function should specificly check for global objects only, not for custom objects or map points!
+	//- keep in mind that bullets can penetrate water and still deal damage.
+	
+	//3) GetClosestPlayerObjectInBetween:
+	//- improve when ColAndreas is enabled, otherwise fall back on existing code.
+	//- this function should specificly check for custom objects only, not for global objects or map points!
+	//- keep in mind that bullets can penetrate water and still deal damage.
+
+	//4) FCNPC_SHOOT_MODE_X:
+	//- add FCNPC_AimAt, FCNPC_AimAtPlayer, FCNPC_TriggerWeaponShot extra parameter with same effect as FCNPC_MOVE_MODE_X, called FCNPC_SHOOT_MODE_X
 
 	return 0;
 }

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -284,12 +284,12 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	}
 
 	// Check if something is in between the origin and the target
-	BYTE byteClosestEntityHitType = BULLET_HIT_TYPE_NONE;
+	/*BYTE byteClosestEntityHitType = BULLET_HIT_TYPE_NONE;
 	WORD wClosestEntity = GetClosestEntityInBetween(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, byteClosestEntityHitType, wPlayerId, bulletSyncDataTarget.wHitID);
 	if (wClosestEntity != 0xFFFF) {
 		bulletSyncDataTarget.wHitID = wClosestEntity;
 		bulletSyncDataTarget.byteHitType = byteClosestEntityHitType;
-	}
+	}*/
 
 	// Get center of hit
 	switch (bulletSyncDataTarget.byteHitType) {

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -272,18 +272,28 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 	// Create the target SendBullet structure
 	CBulletSyncData bulletSyncDataTarget;
-	bulletSyncDataTarget.wHitID = wHitId;
-	bulletSyncDataTarget.byteHitType = byteHitType;
 	bulletSyncDataTarget.byteWeaponID = byteWeaponId;
 	bulletSyncDataTarget.vecHitOrigin = vecOrigin;
 	bulletSyncDataTarget.vecHitTarget = vecPoint;
 	bulletSyncDataTarget.vecCenterOfHit = CVector();
+	bulletSyncDataTarget.wHitID = wHitId;
+	bulletSyncDataTarget.byteHitType = byteHitType;
 	if (!bIsHit) {
 		bulletSyncDataTarget.wHitID = 0xFFFF; // Using 0xFFFF instead of INVALID_PLAYER_ID, because the hitId is not necessarily a player
 		bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
 	}
 
+	// Is something in between the origin and the target
+	CBulletSyncData bulletSyncDataInBetween;
+	bulletSyncDataInBetween.byteWeaponID = bulletSyncDataTarget.byteWeaponID;
+	bulletSyncDataInBetween.vecHitOrigin = bulletSyncDataTarget.vecHitOrigin;
+	bulletSyncDataInBetween.vecHitTarget = CVector();
+	bulletSyncDataInBetween.vecCenterOfHit = CVector();
+	bulletSyncDataTarget.wHitID = 0xFFFF;
+	bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
+
 	// Find player in vecPoint
+	/*
 	if (bIsHit && bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_NONE) {
 		for (WORD i = 0; i <= pNetGame->pPlayerPool->dwPlayerPoolSize; i++) {
 			if (!pServer->GetPlayerManager()->IsPlayerConnected(i) || wPlayerId == i) {
@@ -306,6 +316,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 			}
 		}
 	}
+	*/
 
 	// Get center of hit
 	switch (bulletSyncDataTarget.byteHitType) {

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -270,7 +270,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	pPlayerData->GetPosition(&vecOrigin);
 	vecOrigin += vecOffsetFrom;
 
-	// Create the SendBullet structure
+	// Create the target SendBullet structure
 	CBulletSyncData bulletSyncDataTarget;
 	if (bIsHit) {
 		bulletSyncDataTarget.wHitID = wHitId;
@@ -285,7 +285,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	bulletSyncDataTarget.vecHitOrigin = vecOrigin;
 	bulletSyncDataTarget.vecHitTarget = vecPoint;
 
-	// find player in vecPoint
+	// Find player in vecPoint
 	if (bIsHit && bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_NONE) {
 		for (WORD i = 0; i <= pNetGame->pPlayerPool->dwPlayerPoolSize; i++) {
 			if (!pServer->GetPlayerManager()->IsPlayerConnected(i) || wPlayerId == i) {
@@ -309,7 +309,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		}
 	}
 
-	// get center of hit
+	// Get center of hit
 	switch (bulletSyncDataTarget.byteHitType) {
 	case BULLET_HIT_TYPE_NONE:
 		bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget;
@@ -348,13 +348,13 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		break;
 	}
 
-	// update bullet sync data
+	// Update bullet sync data
 	pPlayerData->SetBulletSync(&bulletSyncDataTarget);
 
-	// call FCNPC_OnWeaponShot
+	// Call FCNPC_OnWeaponShot
 	int send = CCallbackManager::OnWeaponShot(wPlayerId, bulletSyncDataTarget.byteWeaponID, bulletSyncDataTarget.byteHitType, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecCenterOfHit);
 	if (send != 0) {
-		// if it is a NPC
+		// If it is a NPC
 		if (bIsHit && bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_PLAYER && pServer->GetPlayerManager()->IsNpcConnected(bulletSyncDataTarget.wHitID)) {
 			CPlayerData *pHitPlayerData = pServer->GetPlayerManager()->GetAt(bulletSyncDataTarget.wHitID);
 

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -281,23 +281,26 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 	// If the shooter misses his shot
 	if (!bIsHit) {
+		logprintf("TARGET MISSED");
 		bulletSyncDataTarget.wHitID = 0xFFFF; // Using 0xFFFF instead of INVALID_PLAYER_ID, because the hitId is not necessarily a player
 		bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
 	}
 
 	// If the target is not in range
 	if (CMath::GetDistanceBetween3DPoints(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget) > CWeaponInfo::GetDefaultInfo(bulletSyncDataTarget.byteWeaponID).fRange) {
+		logprintf("TARGET OUT OF RANGE");
 		bulletSyncDataTarget.wHitID = 0xFFFF;
 		bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
 	}
 
 	// If something is in between the origin and the target
-	/*BYTE byteClosestEntityHitType = BULLET_HIT_TYPE_NONE;
+	BYTE byteClosestEntityHitType = BULLET_HIT_TYPE_NONE;
 	WORD wClosestEntity = GetClosestEntityInBetween(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataTarget.byteWeaponID, byteClosestEntityHitType, wPlayerId, bulletSyncDataTarget.wHitID);
 	if (wClosestEntity != 0xFFFF) {
-		bulletSyncDataTarget.wHitID = wClosestEntity;
-		bulletSyncDataTarget.byteHitType = byteClosestEntityHitType;
-	}*/
+		logprintf("SOMETHING IN BETWEEN SHOOTER AND TARGET");
+		/*bulletSyncDataTarget.wHitID = wClosestEntity;
+		bulletSyncDataTarget.byteHitType = byteClosestEntityHitType;*/
+	}
 
 	// Get center of hit
 	switch (bulletSyncDataTarget.byteHitType) {
@@ -305,11 +308,13 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_ACTORS) { // Actors don't have a hit type
 			CActor *pActor = pNetGame->pActorPool->pActor[bulletSyncDataTarget.wHitID];
 			if (pActor) {
+				logprintf("HIT ACTOR");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pActor->vecPosition);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pActor->vecPosition;
 			}
 		}
 		else { // Hit nothing
+			logprintf("HIT NOTHING");
 			bulletSyncDataTarget.vecCenterOfHit = CVector(); // Conform with SA-MP native when nothing is hit
 		}
 		break;
@@ -317,6 +322,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_PLAYERS) {
 			CPlayer *pPlayer = pNetGame->pPlayerPool->pPlayer[bulletSyncDataTarget.wHitID];
 			if (pPlayer) {
+				logprintf("HIT PLAYER");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayer->vecPosition;
 				//bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pNPC->vecPosition);
@@ -328,6 +334,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_VEHICLES) { // Vehicle IDs start at 1
 			CVehicle *pVehicle = pNetGame->pVehiclePool->pVehicle[bulletSyncDataTarget.wHitID];
 			if (pVehicle) {
+				logprintf("HIT VEHICLE");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pVehicle->vecPosition);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pVehicle->vecPosition;
 			}
@@ -337,6 +344,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { // Object IDs start at 1
 			CObject *pObject = pNetGame->pObjectPool->pObjects[bulletSyncDataTarget.wHitID];
 			if (pObject) {
+				logprintf("HIT OBJECT");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pObject->matWorld.pos);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pObject->matWorld.pos;
 			}
@@ -346,6 +354,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { // Player object IDs start at 1
 			CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncDataTarget.wHitID];
 			if (pPlayerObject) {
+				logprintf("HIT PLAYER OBJECT");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayerObject->matWorld.pos);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayerObject->matWorld.pos;
 			}
@@ -368,6 +377,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 				pHitPlayerData->ProcessDamage(wPlayerId, sWeaponInfo.fDamage, bulletSyncDataTarget.byteWeaponID, BODY_PART_TORSO);
 				CCallbackManager::OnGiveDamage(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.byteWeaponID, BODY_PART_TORSO, sWeaponInfo.fDamage);
+				logprintf("DAMAGE NPC");
 			}
 		}
 

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -354,15 +354,15 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	// Call FCNPC_OnWeaponShot
 	int send = CCallbackManager::OnWeaponShot(wPlayerId, bulletSyncDataTarget.byteWeaponID, bulletSyncDataTarget.byteHitType, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecCenterOfHit);
 	if (send != 0) {
-		// If it is a NPC
+		// If it is an NPC
 		if (bIsHit && bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_PLAYER && pServer->GetPlayerManager()->IsNpcConnected(bulletSyncDataTarget.wHitID)) {
 			CPlayerData *pHitPlayerData = pServer->GetPlayerManager()->GetAt(bulletSyncDataTarget.wHitID);
 
 			if (pHitPlayerData && !pHitPlayerData->IsInvulnerable() && pHitPlayerData->GetState() != PLAYER_STATE_WASTED) {
-				SWeaponInfo sWeaponInfo = CWeaponInfo::GetDefaultInfo(byteWeaponId);
+				SWeaponInfo sWeaponInfo = CWeaponInfo::GetDefaultInfo(bulletSyncDataTarget.byteWeaponID);
 
-				pHitPlayerData->ProcessDamage(wPlayerId, sWeaponInfo.fDamage, byteWeaponId, BODY_PART_TORSO);
-				CCallbackManager::OnGiveDamage(wPlayerId, bulletSyncDataTarget.wHitID, byteWeaponId, BODY_PART_TORSO, sWeaponInfo.fDamage);
+				pHitPlayerData->ProcessDamage(wPlayerId, sWeaponInfo.fDamage, bulletSyncDataTarget.byteWeaponID, BODY_PART_TORSO);
+				CCallbackManager::OnGiveDamage(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.byteWeaponID, BODY_PART_TORSO, sWeaponInfo.fDamage);
 			}
 		}
 

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -409,8 +409,10 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 	// Call FCNPC_OnWeaponShot
 	int send = CCallbackManager::OnWeaponShot(wPlayerId, bulletSyncDataTarget.byteWeaponID, bulletSyncDataTarget.byteHitType, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecCenterOfHit);
+	logprintf("TYPE %d, ID %d, %.2f, %.2f, %.2f", bulletSyncDataTarget.byteHitType, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecCenterOfHit.fX, bulletSyncDataTarget.vecCenterOfHit.fY, bulletSyncDataTarget.vecCenterOfHit.fZ);
+
+	// Deal damage to the target NPC if the target is an NPC
 	if (send != 0) {
-		// If the target is an NPC
 		if (bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_PLAYER && pServer->GetPlayerManager()->IsNpcConnected(bulletSyncDataTarget.wHitID)) {
 			CPlayerData *pHitPlayerData = pServer->GetPlayerManager()->GetAt(bulletSyncDataTarget.wHitID);
 
@@ -691,7 +693,7 @@ WORD CFunctions::GetClosestVehicleInBetween(const CVector &vecHitOrigin, const C
 		}
 
 		// Is the vehicle on the ray
-		if (CMath::GetDistanceFromRayToPoint(vecHitOrigin, vecHitTarget, pVehicle->vecPosition) > MAX_HIT_RADIUS) {
+		if (CMath::GetDistanceFromRayToPoint(vecHitOrigin, vecHitTarget, pVehicle->vecPosition) > MAX_HIT_RADIUS_VEHICLE) { //Don't use MAX_HIT_RADIUS
 			continue;
 		}
 

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -302,14 +302,16 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	// Get center of hit
 	switch (bulletSyncDataTarget.byteHitType) {
 	case BULLET_HIT_TYPE_NONE:
-		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_ACTORS) { //Actors don't have a hit type
+		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_ACTORS) { // Actors don't have a hit type
 			CActor *pActor = pNetGame->pActorPool->pActor[bulletSyncDataTarget.wHitID];
 			if (pActor) {
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pActor->vecPosition);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pActor->vecPosition;
 			}
 		}
-		else {} //Hit nothing
+		else { // Hit nothing
+			bulletSyncDataTarget.vecCenterOfHit = CVector(); // Conform with SA-MP native when nothing is hit
+		}
 		break;
 	case BULLET_HIT_TYPE_PLAYER:
 		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_PLAYERS) {
@@ -323,7 +325,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		}
 		break;
 	case BULLET_HIT_TYPE_VEHICLE:
-		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_VEHICLES) { //Vehicle IDs start at 1
+		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_VEHICLES) { // Vehicle IDs start at 1
 			CVehicle *pVehicle = pNetGame->pVehiclePool->pVehicle[bulletSyncDataTarget.wHitID];
 			if (pVehicle) {
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pVehicle->vecPosition);
@@ -332,7 +334,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		}
 		break;
 	case BULLET_HIT_TYPE_OBJECT:
-		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { //Object IDs start at 1
+		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { // Object IDs start at 1
 			CObject *pObject = pNetGame->pObjectPool->pObjects[bulletSyncDataTarget.wHitID];
 			if (pObject) {
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pObject->matWorld.pos);
@@ -341,7 +343,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		}
 		break;
 	case BULLET_HIT_TYPE_PLAYER_OBJECT:
-		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { //Player object IDs start at 1
+		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { // Player object IDs start at 1
 			CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncDataTarget.wHitID];
 			if (pPlayerObject) {
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayerObject->matWorld.pos);
@@ -396,7 +398,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 
 	// Check if an NPC is in between the origin and the target
 	float fClosestNPCDistance = 0.0;
-	WORD wClosestNPC = GetClosestNPCInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestNPCDistance, wPlayerId, wTargetId); //Separate function in case we need to handle NPCs differently form players in the future
+	WORD wClosestNPC = GetClosestNPCInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestNPCDistance, wPlayerId, wTargetId); // Separate function in case we need to handle NPCs differently form players in the future
 	if (wClosestNPC != INVALID_PLAYER_ID && (wClosestEntity == 0xFFFF || fClosestNPCDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_PLAYER;
 		fClosestEntityDistance = fClosestNPCDistance;
@@ -407,7 +409,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 	float fClosestActorDistance = 0.0;
 	WORD wClosestActor = GetClosestActorInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestActorDistance);
 	if (wClosestActor != INVALID_ACTOR_ID && (wClosestEntity == 0xFFFF || fClosestActorDistance < fClosestEntityDistance)) {
-		byteHitType = BULLET_HIT_TYPE_NONE; //Actors don't have a hit type, this is conform with the SA-MP native OnPlayerWeaponShot
+		byteHitType = BULLET_HIT_TYPE_NONE; // Actors don't have a hit type, this is conform with the SA-MP native OnPlayerWeaponShot
 		fClosestEntityDistance = fClosestActorDistance;
 		wClosestEntity = wClosestActor;
 	}
@@ -432,14 +434,14 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 
 	// Check if a player object is in between the origin and the target
 	float fClosestPlayerObjectDistance = 0.0;
-	WORD wClosestPlayerObject = GetClosestPlayerObjectInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestPlayerObjectDistance, wPlayerId); //Only checks for player objects of the shooter, not the target
+	WORD wClosestPlayerObject = GetClosestPlayerObjectInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestPlayerObjectDistance, wPlayerId); // Only checks for player objects of the shooter, not the target
 	if (wClosestPlayerObject != INVALID_OBJECT_ID && (wClosestEntity == 0xFFFF || fClosestPlayerObjectDistance < fClosestEntityDistance)) {
 		byteHitType = BULLET_HIT_TYPE_PLAYER_OBJECT;
 		fClosestEntityDistance = fClosestPlayerObjectDistance;
 		wClosestEntity = wClosestPlayerObject;
 	}
 
-	//Check if a map point is in between the origin and the target
+	// Check if a map point is in between the origin and the target
 	float fClosestMapPointDistance = 0.0;
 	WORD wClosestMapPoint = GetClosestMapPointInBetween(vecHitOrigin, vecHitTarget, byteWeaponID, fClosestMapPointDistance);
 	if (wClosestMapPoint != 0 && (wClosestEntity == 0xFFFF || fClosestMapPointDistance < fClosestEntityDistance)) {
@@ -558,7 +560,7 @@ WORD CFunctions::GetClosestVehicleInBetween(const CVector &vecHitOrigin, const C
 	WORD wClosestVehicle = INVALID_VEHICLE_ID;
 
 	// Loop through all the vehicles
-	for (WORD i = 1; i <= pNetGame->pVehiclePool->dwVehiclePoolSize; i++) { //Vehicle IDs start at 1
+	for (WORD i = 1; i <= pNetGame->pVehiclePool->dwVehiclePoolSize; i++) { // Vehicle IDs start at 1
 
 		// Validate the vehicle
 		CVehicle *pVehicle = pNetGame->pVehiclePool->pVehicle[i];
@@ -592,7 +594,7 @@ WORD CFunctions::GetClosestObjectInBetween(const CVector &vecHitOrigin, const CV
 	WORD wClosestObject = INVALID_OBJECT_ID;
 
 	// Loop through all the objects
-	for (WORD i = 1; i < MAX_OBJECTS; i++) { //Object IDs start at 1
+	for (WORD i = 1; i < MAX_OBJECTS; i++) { // Object IDs start at 1
 
 		// Validate the object
 		CObject *pObject = pNetGame->pObjectPool->pObjects[i];
@@ -626,7 +628,7 @@ WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, co
 	WORD wClosestPlayerObject = INVALID_OBJECT_ID;
 
 	// Loop through all the player objects of the shooter
-	for (WORD i = 1; i < MAX_OBJECTS; i++) { //Player object IDs start at 1
+	for (WORD i = 1; i < MAX_OBJECTS; i++) { // Player object IDs start at 1
 
 		// Validate the player object
 		CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][i];

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -275,7 +275,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	bulletSyncDataTarget.byteWeaponID = byteWeaponId;
 	bulletSyncDataTarget.vecHitOrigin = vecOrigin;
 	bulletSyncDataTarget.vecHitTarget = vecPoint;
-	bulletSyncDataTarget.vecCenterOfHit = CVector();
+	bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget;
 	bulletSyncDataTarget.wHitID = wHitId;
 	bulletSyncDataTarget.byteHitType = byteHitType;
 	if (!bIsHit) {
@@ -321,13 +321,12 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	// Get center of hit
 	switch (bulletSyncDataTarget.byteHitType) {
 	case BULLET_HIT_TYPE_NONE:
-		bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget;
 		break;
 	case BULLET_HIT_TYPE_PLAYER:
-		if (bulletSyncDataTarget.wHitID < MAX_PLAYERS) {
+		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_PLAYERS) {
 			CPlayer *pHitPlayerData = pNetGame->pPlayerPool->pPlayer[bulletSyncDataTarget.wHitID];
 			if (pHitPlayerData) {
-				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pHitPlayerData->vecPosition;
+				bulletSyncDataTarget.vecCenterOfHit -= pHitPlayerData->vecPosition;
 			}
 		}
 		break;
@@ -335,7 +334,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_VEHICLES) {
 			CVehicle *pVehicle = pNetGame->pVehiclePool->pVehicle[bulletSyncDataTarget.wHitID];
 			if (pVehicle) {
-				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pVehicle->vecPosition;
+				bulletSyncDataTarget.vecCenterOfHit -= pVehicle->vecPosition;
 			}
 		}
 		break;
@@ -343,7 +342,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
 			CObject *pObject = pNetGame->pObjectPool->pObjects[bulletSyncDataTarget.wHitID];
 			if (pObject) {
-				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pObject->matWorld.pos;
+				bulletSyncDataTarget.vecCenterOfHit -= pObject->matWorld.pos;
 			}
 		}
 		break;
@@ -351,7 +350,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
 			CObject *pObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncDataTarget.wHitID];
 			if (pObject) {
-				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pObject->matWorld.pos;
+				bulletSyncDataTarget.vecCenterOfHit -= pObject->matWorld.pos;
 			}
 		}
 		break;

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -359,9 +359,18 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) { // Player object IDs start at 1
 			CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncDataTarget.wHitID];
 			if (pPlayerObject) {
-				logprintf("HIT PLAYER OBJECT");
+				logprintf("HIT PLAYER OBJECT SHOOTER");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayerObject->matWorld.pos);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayerObject->matWorld.pos;
+			}
+
+			if (pServer->GetPlayerManager()->IsPlayerConnected(wHitId)) { // We currently only handle checking player objects of the target, not the player objects of the closestPlayer/closestNPC
+				pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wHitId][bulletSyncDataTarget.wHitID]; // Use original hit ID to correctly handle target player objects!
+				if (pPlayerObject) {
+					logprintf("HIT PLAYER OBJECT TARGET");
+					bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayerObject->matWorld.pos);
+					bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayerObject->matWorld.pos;
+				}
 			}
 		}
 		break;

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -293,14 +293,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	bulletSyncDataInBetween.byteHitType = BULLET_HIT_TYPE_NONE;
 
 	// Check if something is in between the origin and the target
-	/*
-	GetClosestPlayerInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
-	GetClosestNPCInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
-	GetClosestActorInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
-	GetClosestVehicleInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
-	GetClosestObjectInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
-	GetClosestPlayerObjectInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
-	*/
+	GetClosestEntityInBetween(wPlayerId, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, bulletSyncDataInBetween);
 
 	// If something is in between the origin and the target, make that something the target
 	if (bulletSyncDataInBetween.wHitID != 0xFFFF) {
@@ -308,7 +301,6 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	}
 
 	// Get center of hit
-	/*
 	switch (bulletSyncDataTarget.byteHitType) {
 	case BULLET_HIT_TYPE_NONE:
 		if (bulletSyncDataTarget.wHitID >= 0 && bulletSyncDataTarget.wHitID < MAX_ACTORS) { //Actors don't have a hit type
@@ -351,7 +343,6 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		}
 		break;
 	}
-	*/
 
 	// Update bullet sync data
 	pPlayerData->SetBulletSync(&bulletSyncDataTarget);
@@ -379,6 +370,114 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 
 		// Send it
 		CFunctions::GlobalPacket(&bsSend);
+	}
+}
+
+void CFunctions::GetClosestEntityInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween)
+{
+	WORD wClosestEntity = 0xFFFF;
+	float fClosestEntityDistance = 0.0;
+
+	// Create the playerInBetween SendBullet structure
+	CBulletSyncData bulletSyncDataPlayerInBetween;
+	bulletSyncDataPlayerInBetween.byteWeaponID = bulletSyncDataInBetween.byteWeaponID;
+	bulletSyncDataPlayerInBetween.vecHitOrigin = bulletSyncDataInBetween.vecHitOrigin;
+	bulletSyncDataPlayerInBetween.vecHitTarget = CVector();
+	bulletSyncDataPlayerInBetween.vecCenterOfHit = bulletSyncDataPlayerInBetween.vecHitTarget;
+	bulletSyncDataPlayerInBetween.wHitID = 0xFFFF;
+	bulletSyncDataPlayerInBetween.byteHitType = BULLET_HIT_TYPE_NONE;
+
+	// Check if a player is in between the origin and the target
+	GetClosestPlayerInBetween(wPlayerId, wTargetId, vecHitOrigin, vecHitTarget, bulletSyncDataPlayerInBetween);
+	if (bulletSyncDataPlayerInBetween.wHitID != INVALID_PLAYER_ID && (wClosestEntity == 0xFFFF || fClosestPlayerDistance < fClosestEntityDistance)) {
+		bulletSyncDataInBetween = bulletSyncDataPlayerInBetween;
+		fClosestEntityDistance = fClosestPlayerDistance;
+		wClosestEntity = bulletSyncDataPlayerInBetween.wHitID;
+	}
+
+	// Create the npcInBetween SendBullet structure
+	CBulletSyncData bulletSyncDataNPCInBetween;
+	bulletSyncDataNPCInBetween.byteWeaponID = bulletSyncDataInBetween.byteWeaponID;
+	bulletSyncDataNPCInBetween.vecHitOrigin = bulletSyncDataInBetween.vecHitOrigin;
+	bulletSyncDataNPCInBetween.vecHitTarget = CVector();
+	bulletSyncDataNPCInBetween.vecCenterOfHit = bulletSyncDataNPCInBetween.vecHitTarget;
+	bulletSyncDataNPCInBetween.wHitID = 0xFFFF;
+	bulletSyncDataNPCInBetween.byteHitType = BULLET_HIT_TYPE_NONE;
+
+	// Check if an NPC is in between the origin and the target
+	GetClosestNPCInBetween(wPlayerId, wTargetId, vecHitOrigin, vecHitTarget, bulletSyncDataNPCInBetween);
+	if (bulletSyncDataNPCInBetween.wHitID != INVALID_PLAYER_ID && (wClosestEntity == 0xFFFF || fClosestNPCDistance < fClosestEntityDistance)) {
+		bulletSyncDataInBetween = bulletSyncDataNPCInBetween;
+		fClosestEntityDistance = fClosestNPCDistance;
+		wClosestEntity = bulletSyncDataNPCInBetween.wHitID;
+	}
+
+	// Create the actorInBetween SendBullet structure
+	CBulletSyncData bulletSyncDataActorInBetween;
+	bulletSyncDataActorInBetween.byteWeaponID = bulletSyncDataInBetween.byteWeaponID;
+	bulletSyncDataActorInBetween.vecHitOrigin = bulletSyncDataInBetween.vecHitOrigin;
+	bulletSyncDataActorInBetween.vecHitTarget = CVector();
+	bulletSyncDataActorInBetween.vecCenterOfHit = bulletSyncDataActorInBetween.vecHitTarget;
+	bulletSyncDataActorInBetween.wHitID = 0xFFFF;
+	bulletSyncDataActorInBetween.byteHitType = BULLET_HIT_TYPE_NONE;
+
+	// Check if an actor is in between the origin and the target
+	GetClosestActorInBetween(wPlayerId, wTargetId, vecHitOrigin, vecHitTarget, bulletSyncDataActorInBetween);
+	if (bulletSyncDataActorInBetween.wHitID != INVALID_ACTOR_ID && (wClosestEntity == 0xFFFF || fClosestActorDistance < fClosestEntityDistance)) {
+		bulletSyncDataInBetween = bulletSyncDataActorInBetween;
+		fClosestEntityDistance = fClosestActorDistance;
+		wClosestEntity = bulletSyncDataActorInBetween.wHitID;
+	}
+
+	// Create the vehicleInBetween SendBullet structure
+	CBulletSyncData bulletSyncDataVehicleInBetween;
+	bulletSyncDataVehicleInBetween.byteWeaponID = bulletSyncDataInBetween.byteWeaponID;
+	bulletSyncDataVehicleInBetween.vecHitOrigin = bulletSyncDataInBetween.vecHitOrigin;
+	bulletSyncDataVehicleInBetween.vecHitTarget = CVector();
+	bulletSyncDataVehicleInBetween.vecCenterOfHit = bulletSyncDataVehicleInBetween.vecHitTarget;
+	bulletSyncDataVehicleInBetween.wHitID = 0xFFFF;
+	bulletSyncDataVehicleInBetween.byteHitType = BULLET_HIT_TYPE_NONE;
+
+	// Check if a vehicle is in between the origin and the target
+	GetClosestVehicleInBetween(wPlayerId, wTargetId, vecHitOrigin, vecHitTarget, bulletSyncDataVehicleInBetween);
+	if (bulletSyncDataVehicleInBetween.wHitID != INVALID_VEHICLE_ID && (wClosestEntity == 0xFFFF || fClosestVehicleDistance < fClosestEntityDistance)) {
+		bulletSyncDataInBetween = bulletSyncDataVehicleInBetween;
+		fClosestEntityDistance = fClosestVehicleDistance;
+		wClosestEntity = bulletSyncDataVehicleInBetween.wHitID;
+	}
+
+	// Create the objectInBetween SendBullet structure
+	CBulletSyncData bulletSyncDataObjectInBetween;
+	bulletSyncDataObjectInBetween.byteWeaponID = bulletSyncDataInBetween.byteWeaponID;
+	bulletSyncDataObjectInBetween.vecHitOrigin = bulletSyncDataInBetween.vecHitOrigin;
+	bulletSyncDataObjectInBetween.vecHitTarget = CVector();
+	bulletSyncDataObjectInBetween.vecCenterOfHit = bulletSyncDataObjectInBetween.vecHitTarget;
+	bulletSyncDataObjectInBetween.wHitID = 0xFFFF;
+	bulletSyncDataObjectInBetween.byteHitType = BULLET_HIT_TYPE_NONE;
+
+	// Check if an object is in between the origin and the target
+	GetClosestObjectInBetween(wPlayerId, wTargetId, vecHitOrigin, vecHitTarget, bulletSyncDataObjectInBetween);
+	if (bulletSyncDataObjectInBetween.wHitID != INVALID_OBJECT_ID && (wClosestEntity == 0xFFFF || fClosestObjectDistance < fClosestEntityDistance)) {
+		bulletSyncDataInBetween = bulletSyncDataObjectInBetween;
+		fClosestEntityDistance = fClosestObjectDistance;
+		wClosestEntity = bulletSyncDataObjectInBetween.wHitID;
+	}
+
+	// Create the playerObjectInBetween SendBullet structure
+	CBulletSyncData bulletSyncDataPlayerObjectInBetween;
+	bulletSyncDataPlayerObjectInBetween.byteWeaponID = bulletSyncDataInBetween.byteWeaponID;
+	bulletSyncDataPlayerObjectInBetween.vecHitOrigin = bulletSyncDataInBetween.vecHitOrigin;
+	bulletSyncDataPlayerObjectInBetween.vecHitTarget = CVector();
+	bulletSyncDataPlayerObjectInBetween.vecCenterOfHit = bulletSyncDataPlayerObjectInBetween.vecHitTarget;
+	bulletSyncDataPlayerObjectInBetween.wHitID = 0xFFFF;
+	bulletSyncDataPlayerObjectInBetween.byteHitType = BULLET_HIT_TYPE_NONE;
+
+	// Check if a player object is in between the origin and the target
+	GetClosestPlayerObjectInBetween(wPlayerId, wTargetId, vecHitOrigin, vecHitTarget, bulletSyncDataPlayerObjectInBetween);
+	if (bulletSyncDataPlayerObjectInBetween.wHitID != INVALID_OBJECT_ID && (wClosestEntity == 0xFFFF || fClosestPlayerObjectDistance < fClosestEntityDistance)) {
+		bulletSyncDataInBetween = bulletSyncDataPlayerObjectInBetween;
+		fClosestEntityDistance = fClosestPlayerObjectDistance;
+		wClosestEntity = bulletSyncDataPlayerObjectInBetween.wHitID;
 	}
 }
 

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -310,12 +310,13 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 			if (pActor) {
 				logprintf("HIT ACTOR");
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pActor->vecPosition);
-				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pActor->vecPosition;
+				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget; // When actor is hit use the actor collision position, this is conform with the SA-MP callback OnPlayerWeaponShot
 			}
 		}
 		else if (bulletSyncDataTarget.wHitID == -1) { // Hit map
 			logprintf("HIT MAP");
-			bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget; // When map is hit use the target position, this is conform with the SA-MP callback OnPlayerWeaponShot
+			//bulletSyncDataTarget.vecCenterOfHit = vecHitCollision; // When map is hit use the object collision position, this is conform with the SA-MP callback OnPlayerWeaponShot
+			bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget; //Temporary replacement
 		}
 		else { // Hit nothing
 			logprintf("HIT NOTHING");
@@ -722,6 +723,7 @@ WORD CFunctions::GetClosestMapPointInBetween(const CVector &vecHitOrigin, const 
 	//- currently the code handles map points when the hit type is BULLET_HIT_TYPE_NONE and the hit ID is -1.
 	//- this function should specificly check for map points only, not for global objects or custom objects!
 	//- keep in mind that bullets can penetrate water and still deal damage.
+	//- change the switch for map points in PlayerShoot to use the collision point instead of the target point
 
 	//2) GetClosestObjectInBetween:
 	//- improve when ColAndreas is enabled, otherwise fall back on existing code.

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -292,28 +292,25 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	bulletSyncDataTarget.wHitID = 0xFFFF;
 	bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
 
-	// Find player in vecPoint
 	/*
-	if (bIsHit && bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_NONE) {
-		for (WORD i = 0; i <= pNetGame->pPlayerPool->dwPlayerPoolSize; i++) {
-			if (!pServer->GetPlayerManager()->IsPlayerConnected(i) || wPlayerId == i) {
-				continue;
-			}
+	for (WORD i = 0; i <= pNetGame->pPlayerPool->dwPlayerPoolSize; i++) {
+		if (!pServer->GetPlayerManager()->IsPlayerConnected(i) || wPlayerId == i) {
+			continue;
+		}
 
-			CPlayer *pPlayer = pNetGame->pPlayerPool->pPlayer[i];
-			if (!pPlayer) {
-				continue;
-			}
+		CPlayer *pPlayer = pNetGame->pPlayerPool->pPlayer[i];
+		if (!pPlayer) {
+			continue;
+		}
 
-			bool bIsPlayerOnRay = CMath::GetDistanceFromRayToPoint(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition) < MAX_HIT_RADIUS;
-			bool bIsPlayerInDamageRange = bIsPlayerOnRay && CMath::GetDistanceBetween3DPoints(bulletSyncDataTarget.vecHitOrigin, pPlayer->vecPosition) < MAX_DAMAGE_DISTANCE;
+		bool bIsPlayerOnRay = CMath::GetDistanceFromRayToPoint(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition) < MAX_HIT_RADIUS;
+		bool bIsPlayerInDamageRange = bIsPlayerOnRay && CMath::GetDistanceBetween3DPoints(bulletSyncDataTarget.vecHitOrigin, pPlayer->vecPosition) < MAX_DAMAGE_DISTANCE;
 
-			if (bIsPlayerOnRay && bIsPlayerInDamageRange) {
-				bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_PLAYER;
-				bulletSyncDataTarget.wHitID = i;
-				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition);
-				break;
-			}
+		if (bIsPlayerOnRay && bIsPlayerInDamageRange) {
+			bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_PLAYER;
+			bulletSyncDataTarget.wHitID = i;
+			bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition);
+			break;
 		}
 	}
 	*/

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -307,8 +307,9 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 			CPlayer *pPlayer = pNetGame->pPlayerPool->pPlayer[bulletSyncDataTarget.wHitID];
 			if (pPlayer) {
 				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition);
-				//bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pNPC->vecPosition);
 				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pPlayer->vecPosition;
+				//bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pNPC->vecPosition);
+				//bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pNPC->vecPosition;
 			}
 		}
 		break;
@@ -347,7 +348,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	// Call FCNPC_OnWeaponShot
 	int send = CCallbackManager::OnWeaponShot(wPlayerId, bulletSyncDataTarget.byteWeaponID, bulletSyncDataTarget.byteHitType, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecCenterOfHit);
 	if (send != 0) {
-		// If it is an NPC
+		// If the target is an NPC
 		if (bIsHit && bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_PLAYER && pServer->GetPlayerManager()->IsNpcConnected(bulletSyncDataTarget.wHitID)) {
 			CPlayerData *pHitPlayerData = pServer->GetPlayerManager()->GetAt(bulletSyncDataTarget.wHitID);
 
@@ -397,7 +398,7 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 	float fClosestActorDistance = 0.0;
 	WORD wClosestActor = GetClosestActorInBetween(vecHitOrigin, vecHitTarget, fClosestActorDistance);
 	if (wClosestActor != INVALID_ACTOR_ID && (wClosestEntity == 0xFFFF || fClosestActorDistance < fClosestEntityDistance)) {
-		byteHitType = BULLET_HIT_TYPE_NONE; //Actors don't have a hit type
+		byteHitType = BULLET_HIT_TYPE_NONE; //Actors don't have a hit type, this is conform with the SA-MP native OnPlayerWeaponShot
 		fClosestEntityDistance = fClosestActorDistance;
 		wClosestEntity = wClosestActor;
 	}
@@ -427,6 +428,15 @@ WORD CFunctions::GetClosestEntityInBetween(const CVector &vecHitOrigin, const CV
 		byteHitType = BULLET_HIT_TYPE_PLAYER_OBJECT;
 		fClosestEntityDistance = fClosestPlayerObjectDistance;
 		wClosestEntity = wClosestPlayerObject;
+	}
+
+	//Check if a map point is in between the origin and the target
+	float fClosestMapPointDistance = 0.0;
+	WORD wClosestMapPoint = GetClosestMapPointInBetween(vecHitOrigin, vecHitTarget, fClosestMapPointDistance);
+	if (wClosestMapPoint != 0 && (wClosestEntity == 0xFFFF || fClosestMapPointDistance < fClosestEntityDistance)) {
+		byteHitType = BULLET_HIT_TYPE_OBJECT;
+		fClosestEntityDistance = fClosestMapPointDistance;
+		wClosestEntity = wClosestMapPoint;
 	}
 
 	return wClosestEntity;
@@ -634,4 +644,18 @@ WORD CFunctions::GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, co
 	}
 
 	return wClosestPlayerObject;
+}
+
+WORD CFunctions::GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance)
+{
+	//TODO
+	//- GetClosestPlayerObjectInBetween only checks for player objects of the shooter, not the target
+	//- implement GetClosestMapPointInBetween when ColAndreas is enabled, otherwise return nothing (0)
+	//- improve GetClosestObjectInBetween and GetClosestPlayerObjectInBetween when ColAndreas is enabled, otherwise fall back on existing code
+	//- add FCNPC_AimAt, FCNPC_AimAtPlayer, FCNPC_TriggerWeaponShot extra parameter that disables inbetween checking for certain types (bit masking)
+	//- add FCNPC_AimAt, FCNPC_AimAtPlayer, FCNPC_TriggerWeaponShot extra parameter with same effect as MOVE_MODE_X, called SHOOT_MODE_X
+	//- add SP weapon ranges in CWeaponInfo and use these ranges instead of MAX_DAMAGE_DISTANCE, see column 'weaponRange' in weapon.dat
+	//- add custom hit radii for each entity type and use these ranges instead of MAX_HIT_RADIUS
+
+	return 0;
 }

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -383,7 +383,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 				}
 			}
 			else if (pServer->GetPlayerManager()->IsPlayerConnected(wPlayerObjectOwnerId)) {
-				if (!pServer->GetPlayerManager()->IsNPC(bulletSyncDataTarget.wHitID)) { // Handles player objects of the closestPlayer
+				if (!pServer->GetPlayerManager()->IsNPC(wPlayerObjectOwnerId)) { // Handles player objects of the closestPlayer
 					CObject *pPlayerObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerObjectOwnerId][bulletSyncDataTarget.wHitID];
 					if (pPlayerObject) {
 						logprintf("HIT PLAYER OBJECT CLOSESTPLAYER");

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -271,22 +271,22 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 	vecOrigin += vecOffsetFrom;
 
 	// Create the SendBullet structure
-	CBulletSyncData bulletSyncData;
+	CBulletSyncData bulletSyncDataTarget;
 	if (bIsHit) {
-		bulletSyncData.wHitID = wHitId;
-		bulletSyncData.byteHitType = byteHitType;
+		bulletSyncDataTarget.wHitID = wHitId;
+		bulletSyncDataTarget.byteHitType = byteHitType;
 	}
 	else {
-		bulletSyncData.wHitID = INVALID_PLAYER_ID;
-		bulletSyncData.byteHitType = BULLET_HIT_TYPE_NONE;
+		bulletSyncDataTarget.wHitID = INVALID_PLAYER_ID;
+		bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_NONE;
 	}
-	bulletSyncData.byteWeaponID = byteWeaponId;
-	bulletSyncData.vecCenterOfHit = CVector();
-	bulletSyncData.vecHitOrigin = vecOrigin;
-	bulletSyncData.vecHitTarget = vecPoint;
+	bulletSyncDataTarget.byteWeaponID = byteWeaponId;
+	bulletSyncDataTarget.vecCenterOfHit = CVector();
+	bulletSyncDataTarget.vecHitOrigin = vecOrigin;
+	bulletSyncDataTarget.vecHitTarget = vecPoint;
 
 	// find player in vecPoint
-	if (bIsHit && bulletSyncData.byteHitType == BULLET_HIT_TYPE_NONE) {
+	if (bIsHit && bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_NONE) {
 		for (WORD i = 0; i <= pNetGame->pPlayerPool->dwPlayerPoolSize; i++) {
 			if (!pServer->GetPlayerManager()->IsPlayerConnected(i) || wPlayerId == i) {
 				continue;
@@ -301,68 +301,68 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 			bool bIsPlayerInDamageRange = bIsPlayerOnRay && CMath::GetDistanceBetween3DPoints(vecOrigin, pPlayer->vecPosition) < MAX_DAMAGE_DISTANCE;
 
 			if (bIsPlayerOnRay && bIsPlayerInDamageRange) {
-				bulletSyncData.byteHitType = BULLET_HIT_TYPE_PLAYER;
-				bulletSyncData.wHitID = i;
-				bulletSyncData.vecHitTarget = CMath::GetNearestPointToRay(vecOrigin, vecPoint, pPlayer->vecPosition);
+				bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_PLAYER;
+				bulletSyncDataTarget.wHitID = i;
+				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(vecOrigin, vecPoint, pPlayer->vecPosition);
 				break;
 			}
 		}
 	}
 
 	// get center of hit
-	switch (bulletSyncData.byteHitType) {
+	switch (bulletSyncDataTarget.byteHitType) {
 	case BULLET_HIT_TYPE_NONE:
-		bulletSyncData.vecCenterOfHit = bulletSyncData.vecHitTarget;
+		bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget;
 		break;
 	case BULLET_HIT_TYPE_PLAYER:
-		if (bulletSyncData.wHitID < MAX_PLAYERS) {
-			CPlayer *pHitPlayerData = pNetGame->pPlayerPool->pPlayer[bulletSyncData.wHitID];
+		if (bulletSyncDataTarget.wHitID < MAX_PLAYERS) {
+			CPlayer *pHitPlayerData = pNetGame->pPlayerPool->pPlayer[bulletSyncDataTarget.wHitID];
 			if (pHitPlayerData) {
-				bulletSyncData.vecCenterOfHit = bulletSyncData.vecHitTarget - pHitPlayerData->vecPosition;
+				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pHitPlayerData->vecPosition;
 			}
 		}
 		break;
 	case BULLET_HIT_TYPE_VEHICLE:
-		if (bulletSyncData.wHitID >= 1 && bulletSyncData.wHitID < MAX_VEHICLES) {
-			CVehicle *pVehicle = pNetGame->pVehiclePool->pVehicle[bulletSyncData.wHitID];
+		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_VEHICLES) {
+			CVehicle *pVehicle = pNetGame->pVehiclePool->pVehicle[bulletSyncDataTarget.wHitID];
 			if (pVehicle) {
-				bulletSyncData.vecCenterOfHit = bulletSyncData.vecHitTarget - pVehicle->vecPosition;
+				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pVehicle->vecPosition;
 			}
 		}
 		break;
 	case BULLET_HIT_TYPE_OBJECT:
-		if (bulletSyncData.wHitID >= 1 && bulletSyncData.wHitID < MAX_OBJECTS) {
-			CObject *pObject = pNetGame->pObjectPool->pObjects[bulletSyncData.wHitID];
+		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
+			CObject *pObject = pNetGame->pObjectPool->pObjects[bulletSyncDataTarget.wHitID];
 			if (pObject) {
-				bulletSyncData.vecCenterOfHit = bulletSyncData.vecHitTarget - pObject->matWorld.pos;
+				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pObject->matWorld.pos;
 			}
 		}
 		break;
 	case BULLET_HIT_TYPE_PLAYER_OBJECT:
-		if (bulletSyncData.wHitID >= 1 && bulletSyncData.wHitID < MAX_OBJECTS) {
-			CObject *pObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncData.wHitID];
+		if (bulletSyncDataTarget.wHitID >= 1 && bulletSyncDataTarget.wHitID < MAX_OBJECTS) {
+			CObject *pObject = pNetGame->pObjectPool->pPlayerObjects[wPlayerId][bulletSyncDataTarget.wHitID];
 			if (pObject) {
-				bulletSyncData.vecCenterOfHit = bulletSyncData.vecHitTarget - pObject->matWorld.pos;
+				bulletSyncDataTarget.vecCenterOfHit = bulletSyncDataTarget.vecHitTarget - pObject->matWorld.pos;
 			}
 		}
 		break;
 	}
 
 	// update bullet sync data
-	pPlayerData->SetBulletSync(&bulletSyncData);
+	pPlayerData->SetBulletSync(&bulletSyncDataTarget);
 
 	// call FCNPC_OnWeaponShot
-	int send = CCallbackManager::OnWeaponShot(wPlayerId, bulletSyncData.byteWeaponID, bulletSyncData.byteHitType, bulletSyncData.wHitID, bulletSyncData.vecCenterOfHit);
+	int send = CCallbackManager::OnWeaponShot(wPlayerId, bulletSyncDataTarget.byteWeaponID, bulletSyncDataTarget.byteHitType, bulletSyncDataTarget.wHitID, bulletSyncDataTarget.vecCenterOfHit);
 	if (send != 0) {
 		// if it is a NPC
-		if (bIsHit && bulletSyncData.byteHitType == BULLET_HIT_TYPE_PLAYER && pServer->GetPlayerManager()->IsNpcConnected(bulletSyncData.wHitID)) {
-			CPlayerData *pHitPlayerData = pServer->GetPlayerManager()->GetAt(bulletSyncData.wHitID);
+		if (bIsHit && bulletSyncDataTarget.byteHitType == BULLET_HIT_TYPE_PLAYER && pServer->GetPlayerManager()->IsNpcConnected(bulletSyncDataTarget.wHitID)) {
+			CPlayerData *pHitPlayerData = pServer->GetPlayerManager()->GetAt(bulletSyncDataTarget.wHitID);
 
 			if (pHitPlayerData && !pHitPlayerData->IsInvulnerable() && pHitPlayerData->GetState() != PLAYER_STATE_WASTED) {
 				SWeaponInfo sWeaponInfo = CWeaponInfo::GetDefaultInfo(byteWeaponId);
 
 				pHitPlayerData->ProcessDamage(wPlayerId, sWeaponInfo.fDamage, byteWeaponId, BODY_PART_TORSO);
-				CCallbackManager::OnGiveDamage(wPlayerId, bulletSyncData.wHitID, byteWeaponId, BODY_PART_TORSO, sWeaponInfo.fDamage);
+				CCallbackManager::OnGiveDamage(wPlayerId, bulletSyncDataTarget.wHitID, byteWeaponId, BODY_PART_TORSO, sWeaponInfo.fDamage);
 			}
 		}
 
@@ -370,7 +370,7 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 		RakNet::BitStream bsSend;
 		bsSend.Write(static_cast<BYTE>(ID_BULLET_SYNC));
 		bsSend.Write(wPlayerId);
-		bsSend.Write(reinterpret_cast<char*>(&bulletSyncData), sizeof(CBulletSyncData));
+		bsSend.Write(reinterpret_cast<char*>(&bulletSyncDataTarget), sizeof(CBulletSyncData));
 
 		// Send it
 		CFunctions::GlobalPacket(&bsSend);

--- a/src/CFunctions.cpp
+++ b/src/CFunctions.cpp
@@ -297,13 +297,13 @@ void CFunctions::PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE
 				continue;
 			}
 
-			bool bIsPlayerOnRay = CMath::GetDistanceFromRayToPoint(vecOrigin, vecPoint, pPlayer->vecPosition) < MAX_HIT_RADIUS;
-			bool bIsPlayerInDamageRange = bIsPlayerOnRay && CMath::GetDistanceBetween3DPoints(vecOrigin, pPlayer->vecPosition) < MAX_DAMAGE_DISTANCE;
+			bool bIsPlayerOnRay = CMath::GetDistanceFromRayToPoint(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition) < MAX_HIT_RADIUS;
+			bool bIsPlayerInDamageRange = bIsPlayerOnRay && CMath::GetDistanceBetween3DPoints(bulletSyncDataTarget.vecHitOrigin, pPlayer->vecPosition) < MAX_DAMAGE_DISTANCE;
 
 			if (bIsPlayerOnRay && bIsPlayerInDamageRange) {
 				bulletSyncDataTarget.byteHitType = BULLET_HIT_TYPE_PLAYER;
 				bulletSyncDataTarget.wHitID = i;
-				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(vecOrigin, vecPoint, pPlayer->vecPosition);
+				bulletSyncDataTarget.vecHitTarget = CMath::GetNearestPointToRay(bulletSyncDataTarget.vecHitOrigin, bulletSyncDataTarget.vecHitTarget, pPlayer->vecPosition);
 				break;
 			}
 		}

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -82,7 +82,7 @@ public:
 	static RakNet__GetIndexFromPlayerID_t   pfn__RakNet__GetIndexFromPlayerID;
 
 private:
-
+	static void GetClosestPlayerInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
 
 };
 

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -82,14 +82,14 @@ public:
 	static RakNet__GetIndexFromPlayerID_t   pfn__RakNet__GetIndexFromPlayerID;
 
 private:
-	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, BYTE &byteHitType, WORD &wPlayerObjectOwnerId, BYTE checkInBetween, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, BYTE &byteHitType, WORD &wPlayerObjectOwnerId, CVector &vecHitMap, BYTE checkInBetween, WORD wPlayerId, WORD wTargetId);
 	static WORD GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
 	static WORD GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
 	static WORD GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
 	static WORD GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
 	static WORD GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
 	static WORD GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wOwnerId);
-	static WORD GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
+	static WORD GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, CVector &vecHitMap);
 
 };
 

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -82,13 +82,13 @@ public:
 	static RakNet__GetIndexFromPlayerID_t   pfn__RakNet__GetIndexFromPlayerID;
 
 private:
-	static void GetClosestEntityInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
-	static void GetClosestPlayerInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
-	static void GetClosestNPCInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
-	static void GetClosestActorInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
-	static void GetClosestVehicleInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
-	static void GetClosestObjectInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
-	static void GetClosestPlayerObjectInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
+	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE &byteHitType, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
+	static WORD GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
+	static WORD GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
+	static WORD GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId);
 
 };
 

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -82,6 +82,7 @@ public:
 	static RakNet__GetIndexFromPlayerID_t   pfn__RakNet__GetIndexFromPlayerID;
 
 private:
+	static void GetClosestEntityInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
 	static void GetClosestPlayerInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
 	static void GetClosestNPCInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
 	static void GetClosestActorInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -82,14 +82,14 @@ public:
 	static RakNet__GetIndexFromPlayerID_t   pfn__RakNet__GetIndexFromPlayerID;
 
 private:
-	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, BYTE &byteHitType, WORD &wPlayerObjectOwnerId, CVector &vecHitMap, BYTE checkInBetween, WORD wPlayerId, WORD wTargetId);
-	static WORD GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
-	static WORD GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
-	static WORD GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
-	static WORD GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
-	static WORD GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
-	static WORD GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wOwnerId);
-	static WORD GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, CVector &vecHitMap);
+	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float fTargetDistance, BYTE &byteHitType, WORD &wPlayerObjectOwnerId, CVector &vecHitMap, BYTE checkInBetween, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float fTargetDistance, float &fDistance, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float fTargetDistance, float &fDistance, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float fTargetDistance, float &fDistance);
+	static WORD GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float fTargetDistance, float &fDistance);
+	static WORD GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float fTargetDistance, float &fDistance);
+	static WORD GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float fTargetDistance, float &fDistance, WORD wOwnerId);
+	static WORD GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float fTargetDistance, float &fDistance, CVector &vecHitMap);
 
 };
 

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -48,7 +48,7 @@ public:
 	static CVector *GetVehicleModelInfoEx(int iModelID, int iInfoType);
 	static WORD GetMaxPlayers();
 	static WORD GetMaxNPC();
-	static void PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE byteWeaponId, const CVector &vecPoint, const CVector &vecOffsetFrom, bool bIsHit);
+
 #ifdef SAMP_03DL
 	static int GetSkinBaseID(DWORD dwSkinId);
 #endif
@@ -64,6 +64,8 @@ public:
 	static PlayerID GetPlayerIDFromIndex(int index);
 	static int GetIndexFromPlayerID(PlayerID playerId);
 
+	static void PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE byteWeaponId, const CVector &vecPoint, const CVector &vecOffsetFrom, bool bIsHit);
+
 	// Functions
 	static ClientJoin_RPC_t                 pfn__ClientJoin_RPC;
 	static CPlayerPool__DeletePlayer_t      pfn__CPlayerPool__DeletePlayer;
@@ -78,6 +80,10 @@ public:
 	static RakNet__Receive_t                pfn__RakNet__Receive;
 	static RakNet__GetPlayerIDFromIndex_t   pfn__RakNet__GetPlayerIDFromIndex;
 	static RakNet__GetIndexFromPlayerID_t   pfn__RakNet__GetIndexFromPlayerID;
+
+private:
+
+
 };
 
 #endif

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -83,6 +83,11 @@ public:
 
 private:
 	static void GetClosestPlayerInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
+	static void GetClosestNPCInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
+	static void GetClosestActorInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
+	static void GetClosestVehicleInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
+	static void GetClosestObjectInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
+	static void GetClosestPlayerObjectInBetween(WORD wPlayerId, WORD wTargetId, const CVector &vecHitOrigin, const CVector &vecHitTarget, CBulletSyncData &bulletSyncDataInBetween);
 
 };
 

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -88,7 +88,7 @@ private:
 	static WORD GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
 	static WORD GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
 	static WORD GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
-	static WORD GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId);
+	static WORD GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wOwnerId);
 	static WORD GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
 
 };

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -82,14 +82,14 @@ public:
 	static RakNet__GetIndexFromPlayerID_t   pfn__RakNet__GetIndexFromPlayerID;
 
 private:
-	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE &byteHitType, WORD wPlayerId, WORD wTargetId);
-	static WORD GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId, WORD wTargetId);
-	static WORD GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId, WORD wTargetId);
-	static WORD GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
-	static WORD GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
-	static WORD GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
-	static WORD GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId);
-	static WORD GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
+	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, BYTE &byteHitType, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
+	static WORD GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
+	static WORD GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
+	static WORD GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId);
+	static WORD GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);
 
 };
 

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -89,6 +89,7 @@ private:
 	static WORD GetClosestVehicleInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
 	static WORD GetClosestObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
 	static WORD GetClosestPlayerObjectInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance, WORD wPlayerId);
+	static WORD GetClosestMapPointInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, float &fDistance);
 
 };
 

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -64,7 +64,7 @@ public:
 	static PlayerID GetPlayerIDFromIndex(int index);
 	static int GetIndexFromPlayerID(PlayerID playerId);
 
-	static void PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE byteWeaponId, const CVector &vecPoint, const CVector &vecOffsetFrom, bool bIsHit);
+	static void PlayerShoot(WORD wPlayerId, WORD wHitId, BYTE byteHitType, BYTE byteWeaponId, const CVector &vecPoint, const CVector &vecOffsetFrom, bool bIsHit, BYTE checkInBetween);
 
 	// Functions
 	static ClientJoin_RPC_t                 pfn__ClientJoin_RPC;
@@ -82,7 +82,7 @@ public:
 	static RakNet__GetIndexFromPlayerID_t   pfn__RakNet__GetIndexFromPlayerID;
 
 private:
-	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, BYTE &byteHitType, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, BYTE &byteHitType, BYTE checkInBetween, WORD wPlayerId, WORD wTargetId);
 	static WORD GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
 	static WORD GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
 	static WORD GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);

--- a/src/CFunctions.hpp
+++ b/src/CFunctions.hpp
@@ -82,7 +82,7 @@ public:
 	static RakNet__GetIndexFromPlayerID_t   pfn__RakNet__GetIndexFromPlayerID;
 
 private:
-	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, BYTE &byteHitType, BYTE checkInBetween, WORD wPlayerId, WORD wTargetId);
+	static WORD GetClosestEntityInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, BYTE &byteHitType, WORD &wPlayerObjectOwnerId, BYTE checkInBetween, WORD wPlayerId, WORD wTargetId);
 	static WORD GetClosestPlayerInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
 	static WORD GetClosestNPCInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance, WORD wPlayerId, WORD wTargetId);
 	static WORD GetClosestActorInBetween(const CVector &vecHitOrigin, const CVector &vecHitTarget, BYTE byteWeaponID, float &fDistance);

--- a/src/CPlayerData.hpp
+++ b/src/CPlayerData.hpp
@@ -148,8 +148,8 @@ public:
 	void ToggleInfiniteAmmo(bool bToggle);
 	bool HasInfiniteAmmo();
 
-	void AimAt(const CVector &vecPoint, bool bShoot, int iShootDelay, bool bSetAngle, const CVector &vecOffsetFrom);
-	void AimAtPlayer(WORD wHitId, bool bShoot, int iShootDelay, bool bSetAngle, const CVector &vecOffset, const CVector &vecOffsetFrom);
+	void AimAt(const CVector &vecPoint, bool bShoot, int iShootDelay, bool bSetAngle, const CVector &vecOffsetFrom, BYTE checkInBetween);
+	void AimAtPlayer(WORD wHitId, bool bShoot, int iShootDelay, bool bSetAngle, const CVector &vecOffset, const CVector &vecOffsetFrom, BYTE checkInBetween);
 	void UpdateAimingData(const CVector &vecPoint, bool bSetAngle);
 	void StopAim();
 	bool MeleeAttack(int iTime, bool bUseFightstyle);
@@ -259,6 +259,7 @@ private:
 	WORD m_wHitId;
 	bool m_bAimSetAngle;
 	BYTE m_byteHitType;
+	BYTE m_byteCheckInBetween;
 	WORD m_wVehicleToEnter;
 	BYTE m_byteSeatToEnter;
 	WORD m_wLastDamagerId;

--- a/src/CWeaponInfo.cpp
+++ b/src/CWeaponInfo.cpp
@@ -11,53 +11,54 @@
 #include "Main.hpp"
 
 static SWeaponInfo g_sDefaultWeaponInfo[MAX_WEAPONS] = {
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // fists (0)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_BRASSKNUCKLE (1)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_GOLFCLUB (2)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_NITESTICK (3)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_KNIFE (4)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_BAT (5)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_SHOVEL (6)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_POOLSTICK (7)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_KATANA (8)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   30,   0,    1.0f}, // WEAPON_CHAINSAW (9)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_DILDO (10)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_DILDO2 (11)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_VIBRATOR (12)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_VIBRATOR2 (13)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_FLOWER (14)
-	{WEAPON_TYPE_MELEE,   5.0f,  0,   250,  0,    1.0f}, // WEAPON_CANE (15)
-	{WEAPON_TYPE_THROW,   5.0f,  1,   500,  0,    1.0f}, // WEAPON_GRENADE (16)
-	{WEAPON_TYPE_THROW,   5.0f,  1,   500,  0,    1.0f}, // WEAPON_TEARGAS (17)
-	{WEAPON_TYPE_THROW,   5.0f,  1,   500,  0,    1.0f}, // WEAPON_MOLTOV (18)
-	{WEAPON_TYPE_NONE,    0.0f,  0,   0,    0,    1.0f}, // nothing (19)
-	{WEAPON_TYPE_NONE,    0.0f,  0,   0,    0,    1.0f}, // nothing (20)
-	{WEAPON_TYPE_NONE,    0.0f,  0,   0,    0,    1.0f}, // nothing (21)
-	{WEAPON_TYPE_SHOOT,   8.25f, 17,  350,  1300, 1.0f}, // WEAPON_COLT45 (22)
-	{WEAPON_TYPE_SHOOT,   13.2f, 17,  450,  1300, 1.0f}, // WEAPON_SILENCED (23)
-	{WEAPON_TYPE_SHOOT,   46.2f, 7,   950,  1300, 1.0f}, // WEAPON_DEAGLE (24)
-	{WEAPON_TYPE_SHOOT,   30.0f, 1,   1100, 0,    1.0f}, // WEAPON_SHOTGUN (25)
-	{WEAPON_TYPE_SHOOT,   30.0f, 2,   300,  1300, 1.0f}, // WEAPON_SAWEDOFF (26)
-	{WEAPON_TYPE_SHOOT,   30.0f, 7,   400,  1500, 1.0f}, // WEAPON_SHOTGSPA (27)
-	{WEAPON_TYPE_SHOOT,   6.6f,  50,  110,  1500, 1.0f}, // WEAPON_UZI (28)
-	{WEAPON_TYPE_SHOOT,   8.25f, 30,  95,   1650, 1.0f}, // WEAPON_MP5 (29)
-	{WEAPON_TYPE_SHOOT,   9.9f,  30,  120,  1900, 1.0f}, // WEAPON_AK47 (30)
-	{WEAPON_TYPE_SHOOT,   9.9f,  50,  120,  1900, 1.0f}, // WEAPON_M4 (31)
-	{WEAPON_TYPE_SHOOT,   6.6f,  50,  110,  1500, 1.0f}, // WEAPON_TEC9 (32)
-	{WEAPON_TYPE_SHOOT,   24.8f, 1,   1050, 0,    1.0f}, // WEAPON_RIFLE (33)
-	{WEAPON_TYPE_SHOOT,   41.3f, 1,   1050, 0,    1.0f}, // WEAPON_SNIPER (34)
-	{WEAPON_TYPE_ROCKET,  5.0f,  1,   1050, 0,    1.0f}, // WEAPON_ROCKETLAUNCHER (35)
-	{WEAPON_TYPE_ROCKET,  5.0f,  1,   1050, 0,    1.0f}, // WEAPON_HEATSEEKER (36)
-	{WEAPON_TYPE_SPRAY,   5.0f,  500, 500,  500,  1.0f}, // WEAPON_FLAMETHROWER (37)
-	{WEAPON_TYPE_SHOOT,   46.2f, 500, 20,   200,  1.0f}, // WEAPON_MINIGUN (38)
-	{WEAPON_TYPE_SPECIAL, 5.0f,  1,   500,  0,    1.0f}, // WEAPON_SATCHEL (39)
-	{WEAPON_TYPE_SPECIAL, 5.0f,  1,   500,  0,    1.0f}, // WEAPON_BOMB (40)
-	{WEAPON_TYPE_SPRAY,   5.0f,  500, 10,   200,  1.0f}, // WEAPON_SPRAYCAN (41)
-	{WEAPON_TYPE_SPRAY,   5.0f,  500, 10,   200,  1.0f}, // WEAPON_FIREEXTINGUISHER (42)
-	{WEAPON_TYPE_SPECIAL, 0.0f,  1,   1200, 0,    1.0f}, // WEAPON_CAMERA (43)
-	{WEAPON_TYPE_SPECIAL, 0.0f,  0,   1500, 0,    1.0f}, // WEAPON_NIGHTVISION (44)
-	{WEAPON_TYPE_SPECIAL, 0.0f,  0,   1500, 0,    1.0f}, // WEAPON_INFRARED (45)
-	{WEAPON_TYPE_SPECIAL, 0.0f,  1,   1500, 0,    1.0f} // WEAPON_PARACHUTE (46)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // fists (0)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_BRASSKNUCKLE (1)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_GOLFCLUB (2)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_NITESTICK (3)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_KNIFE (4)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_BAT (5)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_SHOVEL (6)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_POOLSTICK (7)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_KATANA (8)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   30,   0,    1.0f}, // WEAPON_CHAINSAW (9)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_DILDO (10)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_DILDO2 (11)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_VIBRATOR (12)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_VIBRATOR2 (13)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_FLOWER (14)
+	{WEAPON_TYPE_MELEE,   5.0f,  1.6f,   0,   250,  0,    1.0f}, // WEAPON_CANE (15)
+	{WEAPON_TYPE_THROW,   5.0f,  40.0f,  1,   500,  0,    1.0f}, // WEAPON_GRENADE (16)
+	{WEAPON_TYPE_THROW,   5.0f,  40.0f,  1,   500,  0,    1.0f}, // WEAPON_TEARGAS (17)
+	{WEAPON_TYPE_THROW,   5.0f,  40.0f,  1,   500,  0,    1.0f}, // WEAPON_MOLTOV (18)
+	{WEAPON_TYPE_NONE,    0.0f,  0.0f,   0,   0,    0,    1.0f}, // nothing (19)
+	{WEAPON_TYPE_NONE,    0.0f,  0.0f,   0,   0,    0,    1.0f}, // nothing (20)
+	{WEAPON_TYPE_NONE,    0.0f,  0.0f,   0,   0,    0,    1.0f}, // nothing (21)
+	{WEAPON_TYPE_SHOOT,   8.25f, 35.0f,  17,  350,  1300, 1.0f}, // WEAPON_COLT45 (22)
+	{WEAPON_TYPE_SHOOT,   13.2f, 35.0f,  17,  450,  1300, 1.0f}, // WEAPON_SILENCED (23)
+	{WEAPON_TYPE_SHOOT,   46.2f, 35.0f,  7,   950,  1300, 1.0f}, // WEAPON_DEAGLE (24)
+	{WEAPON_TYPE_SHOOT,   30.0f, 40.0f,  1,   1100, 0,    1.0f}, // WEAPON_SHOTGUN (25)
+	{WEAPON_TYPE_SHOOT,   30.0f, 35.0f,  2,   300,  1300, 1.0f}, // WEAPON_SAWEDOFF (26)
+	{WEAPON_TYPE_SHOOT,   30.0f, 40.0f,  7,   400,  1500, 1.0f}, // WEAPON_SHOTGSPA (27)
+	{WEAPON_TYPE_SHOOT,   6.6f,  35.0f,  50,  110,  1500, 1.0f}, // WEAPON_UZI (28)
+	{WEAPON_TYPE_SHOOT,   8.25f, 45.0f,  30,  95,   1650, 1.0f}, // WEAPON_MP5 (29)
+	{WEAPON_TYPE_SHOOT,   9.9f,  70.0f,  30,  120,  1900, 1.0f}, // WEAPON_AK47 (30)
+	{WEAPON_TYPE_SHOOT,   9.9f,  90.0f,  50,  120,  1900, 1.0f}, // WEAPON_M4 (31)
+	{WEAPON_TYPE_SHOOT,   6.6f,  35.0f,  50,  110,  1500, 1.0f}, // WEAPON_TEC9 (32)
+	{WEAPON_TYPE_SHOOT,   24.8f, 100.0f, 1,   1050, 0,    1.0f}, // WEAPON_RIFLE (33)
+	{WEAPON_TYPE_SHOOT,   41.3f, 100.0f, 1,   1050, 0,    1.0f}, // WEAPON_SNIPER (34)
+	{WEAPON_TYPE_ROCKET,  5.0f,  55.0f,  1,   1050, 0,    1.0f}, // WEAPON_ROCKETLAUNCHER (35)
+	{WEAPON_TYPE_ROCKET,  5.0f,  55.0f,  1,   1050, 0,    1.0f}, // WEAPON_HEATSEEKER (36)
+	{WEAPON_TYPE_SPRAY,   5.0f,  5.1f,   500, 500,  500,  1.0f}, // WEAPON_FLAMETHROWER (37)
+	{WEAPON_TYPE_SHOOT,   46.2f, 75.0f,  500, 20,   200,  1.0f}, // WEAPON_MINIGUN (38)
+	{WEAPON_TYPE_SPECIAL, 5.0f,  40.0f,  1,   500,  0,    1.0f}, // WEAPON_SATCHEL (39)
+	{WEAPON_TYPE_SPECIAL, 5.0f,  25.0f,  1,   500,  0,    1.0f}, // WEAPON_BOMB (40)
+	{WEAPON_TYPE_SPRAY,   5.0f,  6.1f,   500, 10,   200,  1.0f}, // WEAPON_SPRAYCAN (41)
+	{WEAPON_TYPE_SPRAY,   5.0f,  10.1f,  500, 10,   200,  1.0f}, // WEAPON_FIREEXTINGUISHER (42)
+	{WEAPON_TYPE_SPECIAL, 0.0f,  100.0f, 1,   1200, 0,    1.0f}, // WEAPON_CAMERA (43)
+	{WEAPON_TYPE_SPECIAL, 0.0f,  200.0f, 0,   1500, 0,    1.0f}, // WEAPON_NIGHTVISION (44)
+	{WEAPON_TYPE_SPECIAL, 0.0f,  200.0f, 0,   1500, 0,    1.0f}, // WEAPON_INFRARED (45)
+
+	{WEAPON_TYPE_SPECIAL, 0.0f,  1.6f,  1,   1500, 0,    1.0f} // WEAPON_PARACHUTE (46)
 };
 
 CWeaponInfo::CWeaponInfo()
@@ -147,6 +148,25 @@ bool CWeaponInfo::SetDamage(BYTE byteWeaponId, float fDamage)
 	}
 
 	m_pWeaponInfo[byteWeaponId]->fDamage = fDamage;
+	return true;
+}
+
+float CWeaponInfo::GetRange(BYTE byteWeaponId)
+{
+	if (!IsValid(byteWeaponId)) {
+		return 0.0f;
+	}
+
+	return m_pWeaponInfo[byteWeaponId]->fRange;
+}
+
+bool CWeaponInfo::SetRange(BYTE byteWeaponId, float fRange)
+{
+	if (!IsValid(byteWeaponId)) {
+		return false;
+	}
+
+	m_pWeaponInfo[byteWeaponId]->fRange = fRange;
 	return true;
 }
 

--- a/src/CWeaponInfo.hpp
+++ b/src/CWeaponInfo.hpp
@@ -27,6 +27,7 @@ struct SWeaponInfo
 {
 	int iType;
 	float fDamage;
+	float fRange;
 	int iClipSize;
 	int iShootTime;
 	int iReloadTime;
@@ -50,6 +51,9 @@ public:
 
 	float GetDamage(BYTE byteWeaponId);
 	bool SetDamage(BYTE byteWeaponId, float fDamage);
+
+	float GetRange(BYTE byteWeaponId);
+	bool SetRange(BYTE byteWeaponId, float fRange);
 
 	int GetClipSize(BYTE byteWeaponId);
 	bool SetClipSize(BYTE byteWeaponId, int iClipSize);

--- a/src/Common.h
+++ b/src/Common.h
@@ -17,7 +17,6 @@ extern logprintf_t          logprintf;
 
 // Settings
 #define MAX_HIT_RADIUS                  0.4f
-#define MAX_DAMAGE_DISTANCE             200.0f
 #define MAX_DISTANCE_TO_ENTER_VEHICLE   30.0f
 #define MIN_VEHICLE_GO_TO_DISTANCE      1.0f
 #define DEFAULT_UPDATE_RATE             50

--- a/src/Common.h
+++ b/src/Common.h
@@ -17,6 +17,7 @@ extern logprintf_t          logprintf;
 
 // Settings
 #define MAX_HIT_RADIUS                  0.4f
+#define MAX_HIT_RADIUS_VEHICLE          1.0f
 #define MAX_DISTANCE_TO_ENTER_VEHICLE   30.0f
 #define MIN_VEHICLE_GO_TO_DISTANCE      1.0f
 #define DEFAULT_UPDATE_RATE             50

--- a/src/Common.h
+++ b/src/Common.h
@@ -46,6 +46,19 @@ extern logprintf_t          logprintf;
 #define UPDATE_STATE_ONFOOT     1
 #define UPDATE_STATE_DRIVER     2
 #define UPDATE_STATE_PASSENGER  3
+
+// Check in between shot (type BYTE suffices)
+#define FCNPC_SHOOT_CHECK_NONE           (0)
+#define FCNPC_SHOOT_CHECK_PLAYER         (1)
+#define FCNPC_SHOOT_CHECK_NPC            (2)
+#define FCNPC_SHOOT_CHECK_ACTOR          (4)
+#define FCNPC_SHOOT_CHECK_VEHICLE        (8)
+#define FCNPC_SHOOT_CHECK_OBJECT         (16)
+#define FCNPC_SHOOT_CHECK_POBJECT_ORIG   (32)
+#define FCNPC_SHOOT_CHECK_POBJECT_TARG   (64)
+#define FCNPC_SHOOT_CHECK_MAP            (128)
+#define FCNPC_SHOOT_CHECK_ALL            (255)
+
 // Movement type
 #define MOVE_TYPE_AUTO      -1
 #define MOVE_TYPE_WALK      0

--- a/src/FCNPC.inc.in
+++ b/src/FCNPC.inc.in
@@ -25,6 +25,17 @@ public FCNPC_IncludeVersion = FCNPC_INCLUDE_VERSION;
 #endif
 
 // Definitions
+#define FCNPC_SHOOT_CHECK_NONE           (0)
+#define FCNPC_SHOOT_CHECK_PLAYER         (1)
+#define FCNPC_SHOOT_CHECK_NPC            (2)
+#define FCNPC_SHOOT_CHECK_ACTOR          (4)
+#define FCNPC_SHOOT_CHECK_VEHICLE        (8)
+#define FCNPC_SHOOT_CHECK_OBJECT         (16)
+#define FCNPC_SHOOT_CHECK_POBJECT_ORIG   (32)
+#define FCNPC_SHOOT_CHECK_POBJECT_TARG   (64)
+#define FCNPC_SHOOT_CHECK_MAP            (128)
+#define FCNPC_SHOOT_CHECK_ALL            (255)
+
 #define FCNPC_MOVE_TYPE_AUTO       (-1)
 #define FCNPC_MOVE_TYPE_WALK       (0)
 #define FCNPC_MOVE_TYPE_RUN        (1)
@@ -197,8 +208,8 @@ native bool:FCNPC_IsMoving(npcid);
 native bool:FCNPC_IsMovingAtPlayer(npcid, playerid);
 native FCNPC_GetDestinationPoint(npcid, &Float:x, &Float:y, &Float:z);
 
-native FCNPC_AimAt(npcid, Float:x, Float:y, Float:z, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
-native FCNPC_AimAtPlayer(npcid, playerid, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_x = 0.0, Float:offset_y = 0.0, Float:offset_z = 0.0, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
+native FCNPC_AimAt(npcid, Float:x, Float:y, Float:z, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween = FCNPC_SHOOT_CHECK_ALL);
+native FCNPC_AimAtPlayer(npcid, playerid, bool:shoot = false, shoot_delay = -1, bool:setangle = true, Float:offset_x = 0.0, Float:offset_y = 0.0, Float:offset_z = 0.0, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween = FCNPC_SHOOT_CHECK_ALL);
 native FCNPC_StopAim(npcid);
 native FCNPC_MeleeAttack(npcid, delay = -1, bool:fightstyle = false);
 native FCNPC_StopAttack(npcid);
@@ -208,7 +219,7 @@ native bool:FCNPC_IsAimingAtPlayer(npcid, playerid);
 native FCNPC_GetAimingPlayer(npcid);
 native bool:FCNPC_IsShooting(npcid);
 native bool:FCNPC_IsReloading(npcid);
-native FCNPC_TriggerWeaponShot(npcid, weaponid, hittype, hitid, Float:x, Float:y, Float:z, bool:ishit = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
+native FCNPC_TriggerWeaponShot(npcid, weaponid, hittype, hitid, Float:x, Float:y, Float:z, bool:ishit = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween = FCNPC_SHOOT_CHECK_ALL);
 
 native FCNPC_EnterVehicle(npcid, vehicleid, seatid, type = FCNPC_MOVE_TYPE_WALK);
 native FCNPC_ExitVehicle(npcid);

--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -2015,6 +2015,7 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_AimAt(AMX *amx, cell *params)
 	int iShootDelay = static_cast<int>(params[6]);
 	bool bSetAngle = static_cast<int>(params[7]) != 0;
 	CVector vecOffsetFrom(amx_ctof(params[8]), amx_ctof(params[9]), amx_ctof(params[10]));
+	BYTE checkInBetween = static_cast<BYTE>(params[11]);
 
 	// Make sure the player is valid
 	CPlayerData *pPlayerData = pServer->GetPlayerManager()->GetAt(wNpcId);
@@ -2034,7 +2035,7 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_AimAt(AMX *amx, cell *params)
 		case WEAPON_TYPE_SPRAY:
 		case WEAPON_TYPE_THROW:
 			pPlayerData->StopAim();
-			pPlayerData->AimAt(vecPoint, bShoot, iShootDelay, bSetAngle, vecOffsetFrom);
+			pPlayerData->AimAt(vecPoint, bShoot, iShootDelay, bSetAngle, vecOffsetFrom, checkInBetween);
 			return 1;
 	}
 
@@ -2053,6 +2054,7 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_AimAtPlayer(AMX *amx, cell *params)
 	bool bSetAngle = static_cast<int>(params[5]) != 0;
 	CVector vecOffsetTo(amx_ctof(params[6]), amx_ctof(params[7]), amx_ctof(params[8]));
 	CVector vecOffsetFrom(amx_ctof(params[9]), amx_ctof(params[10]), amx_ctof(params[11]));
+	BYTE checkInBetween = static_cast<BYTE>(params[12]);
 
 	// Make sure the npc is valid
 	CPlayerData *pPlayerData = pServer->GetPlayerManager()->GetAt(wNpcId);
@@ -2074,7 +2076,7 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_AimAtPlayer(AMX *amx, cell *params)
 		case WEAPON_TYPE_SPRAY:
 		case WEAPON_TYPE_THROW:
 			pPlayerData->StopAim();
-			pPlayerData->AimAtPlayer(wPlayerId, bShoot, iShootDelay, bSetAngle, vecOffsetTo, vecOffsetFrom);
+			pPlayerData->AimAtPlayer(wPlayerId, bShoot, iShootDelay, bSetAngle, vecOffsetTo, vecOffsetFrom, checkInBetween);
 			return 1;
 	}
 
@@ -3341,7 +3343,7 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_IsMoveModeUsed(AMX *amx, cell *params)
 	return pServer->IsMoveModeEnabled(iMoveMode);
 }
 
-// native FCNPC_TriggerWeaponShot(npcid, weaponid, hittype, hitid, Float:x, Float:y, Float:z, bool:ishit = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0);
+// native FCNPC_TriggerWeaponShot(npcid, weaponid, hittype, hitid, Float:x, Float:y, Float:z, bool:ishit = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween);
 cell AMX_NATIVE_CALL CNatives::FCNPC_TriggerWeaponShot(AMX *amx, cell *params)
 {
 	CHECK_PARAMS(11, "FCNPC_TriggerWeaponShot");
@@ -3354,12 +3356,13 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_TriggerWeaponShot(AMX *amx, cell *params)
 	CVector vecPoint(amx_ctof(params[5]), amx_ctof(params[6]), amx_ctof(params[7]));
 	bool bIsHit = static_cast<int>(params[8]) != 0;
 	CVector vecOffsetFrom(amx_ctof(params[9]), amx_ctof(params[10]), amx_ctof(params[11]));
+	BYTE checkInBetween = static_cast<BYTE>(params[12]);
 
 	if (!pServer->GetPlayerManager()->IsNpcConnected(wNpcId)) {
 		return 0;
 	}
 
-	CFunctions::PlayerShoot(wNpcId, wHitId, byteHitType, byteWeaponId, vecPoint, vecOffsetFrom, bIsHit);
+	CFunctions::PlayerShoot(wNpcId, wHitId, byteHitType, byteWeaponId, vecPoint, vecOffsetFrom, bIsHit, checkInBetween);
 	return 1;
 }
 

--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -2006,7 +2006,7 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_GetWeaponDefaultInfo(AMX *amx, cell *params
 
 cell AMX_NATIVE_CALL CNatives::FCNPC_AimAt(AMX *amx, cell *params)
 {
-	CHECK_PARAMS(10, "FCNPC_AimAt");
+	CHECK_PARAMS(11, "FCNPC_AimAt");
 
 	// Get the params
 	WORD wNpcId = static_cast<WORD>(params[1]);
@@ -2044,7 +2044,7 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_AimAt(AMX *amx, cell *params)
 
 cell AMX_NATIVE_CALL CNatives::FCNPC_AimAtPlayer(AMX *amx, cell *params)
 {
-	CHECK_PARAMS(11, "FCNPC_AimAtPlayer");
+	CHECK_PARAMS(12, "FCNPC_AimAtPlayer");
 
 	// Get the params
 	WORD wNpcId = static_cast<WORD>(params[1]);
@@ -3346,7 +3346,7 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_IsMoveModeUsed(AMX *amx, cell *params)
 // native FCNPC_TriggerWeaponShot(npcid, weaponid, hittype, hitid, Float:x, Float:y, Float:z, bool:ishit = true, Float:offset_from_x = 0.0, Float:offset_from_y = 0.0, Float:offset_from_z = 0.0, checkInBetween);
 cell AMX_NATIVE_CALL CNatives::FCNPC_TriggerWeaponShot(AMX *amx, cell *params)
 {
-	CHECK_PARAMS(11, "FCNPC_TriggerWeaponShot");
+	CHECK_PARAMS(12, "FCNPC_TriggerWeaponShot");
 
 	// Get the params
 	WORD wNpcId = static_cast<WORD>(params[1]);

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -944,7 +944,7 @@ struct CActor
 	float			fHealth;
 	DWORD			pad;
 	float			fAngle;
-	CVector			vecPos;
+	CVector			vecPosition;
 	BYTE			pad8[12];
 	BYTE			byteInvulnerable;
 	WORD			wActorID;


### PR DESCRIPTION
- Fix code to handle missed shots
- Add code to handle out of range shots
- Add code to handle things in between the origin and the target
- Fix code to handle center of hit of different hit types
- Add code to handle center of hit of 'new' hit types and differentiate between all of them
- Add private function for each type in between the origin and the target
  - players
  - NPCs
  - actors
  - vehicles
  - global objects
  - player objects shooter
  - player objects target
  - player objects closestPlayer when closestPlayer is closest entity
  - player objects closestNPC when closestNPC is closest entity
  - map (needs further implementation when ColAndreas is implemented)
- Add general private function that calls the private functions of each type
- Remove MAX_DAMAGE_DISTANCE and use weapon ranges instead
- Add Single Player weapon ranges (weapon.dat file) to CWeaponInfo
- Add flags to disable checking for certain types
```
FCNPC_SHOOT_CHECK_NONE		(0)
FCNPC_SHOOT_CHECK_PLAYER	(1)
FCNPC_SHOOT_CHECK_NPC		(2)
FCNPC_SHOOT_CHECK_ACTOR		(4)
FCNPC_SHOOT_CHECK_VEHICLE	(8)
FCNPC_SHOOT_CHECK_OBJECT	(16)
FCNPC_SHOOT_CHECK_POBJECT_ORIG	(32)
FCNPC_SHOOT_CHECK_POBJECT_TARG	(64)
FCNPC_SHOOT_CHECK_MAP		(128)
FCNPC_SHOOT_CHECK_ALL		(255)
```
- FCNPC_SHOOT_CHECK_POBJECT_TARG handles checking for playerobjects of the target, playerobjects of the closestPlayer and playerobjects of the closestNPC. Since it will be rare the an object is only used for certain players, I decided to combine these into one flag
- Add flag parameter to FCNPC_AimAt(Player) and FCNPC_TriggerWeaponShot
- Increase vehicle hit radius
- Add very useful debug logs (in comments)