### PR TITLE
MapAndreas and FCNPC_SetMinHeightPosCall fix

### DIFF
--- a/src/CPlayerData.cpp
+++ b/src/CPlayerData.cpp
@@ -1051,12 +1051,12 @@ void CPlayerData::UpdateHeightPos(CVector *pvecPosition)
 	}
 
 	if (iMoveMode != MOVE_MODE_NONE) {
-		if (m_fMinHeightPos < 0.0f) {
-			pvecPosition->fZ = fNewZ;
-		} else if (m_fMinHeightPos <= std::abs(fNewZ - pvecPosition->fZ)) {
+		if (m_fMinHeightPos >= 0.0f && m_fMinHeightPos <= std::abs(fNewZ - pvecPosition->fZ)) {
 			if (CCallbackManager::OnChangeHeightPos(m_wPlayerId, fNewZ, pvecPosition->fZ)) {
 				pvecPosition->fZ = fNewZ;
 			}
+		} else {
+			pvecPosition->fZ = fNewZ;
 		}
 	}
 }

--- a/src/CServer.cpp
+++ b/src/CServer.cpp
@@ -24,7 +24,6 @@ CServer::CServer(eSAMPVersion version)
 	m_pNodeManager = NULL;
 	m_pMovePath = NULL;
 	m_pRecordManager = NULL;
-	m_pMapAndreas = NULL;
 	m_pColAndreas = NULL;
 	// Initialize the update rate
 	m_dwUpdateRate = DEFAULT_UPDATE_RATE;
@@ -49,7 +48,6 @@ CServer::~CServer()
 	SAFE_DELETE(m_pNodeManager);
 	SAFE_DELETE(m_pMovePath);
 	SAFE_DELETE(m_pRecordManager);
-	SAFE_DELETE(m_pMapAndreas);
 	SAFE_DELETE(m_pColAndreas);
 }
 
@@ -74,9 +72,6 @@ BYTE CServer::Initialize()
 
 	// Create the record instance
 	m_pRecordManager = new CRecordManager;
-
-	// Create the MapAndreas instance
-	m_pMapAndreas = new CMapAndreas;
 
 	// Create the ColAndreas instance
 	m_pColAndreas = new ColAndreasWorld;
@@ -132,9 +127,11 @@ CRecordManager *CServer::GetRecordManager()
 	return m_pRecordManager;
 }
 
+extern CMapAndreas MapAndreas;
+
 CMapAndreas *CServer::GetMapAndreas()
 {
-	return m_pMapAndreas;
+	return &MapAndreas;
 }
 
 ColAndreasWorld *CServer::GetColAndreas()

--- a/src/CServer.hpp
+++ b/src/CServer.hpp
@@ -69,7 +69,6 @@ private:
 	CPlayerManager *m_pPlayerDataManager;
 	CNodeManager *m_pNodeManager;
 	CRecordManager *m_pRecordManager;
-	CMapAndreas *m_pMapAndreas;
 	ColAndreasWorld *m_pColAndreas;
 	CMovePath *m_pMovePath;
 	DWORD m_dwUpdateRate;


### PR DESCRIPTION
This pull request fixes two (unrelated) things:
* The integration with MapAndreas does not work at all: the original natives use their own instance, but the CServer has its own instance that is never initialized. This simply uses the natives' instance.
* `FCNPC_SetMinHeightPosCall` causes the new Z coordinate *not* to be applied when the difference is within the accepted range (otherwise `FCNPC_OnChangeHeightPos` is called which works fine). This changes that so that the new value is rejected if and only if `FCNPC_OnChangeHeightPos` returns false.